### PR TITLE
sync with upstream PR

### DIFF
--- a/index.html
+++ b/index.html
@@ -1260,7 +1260,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 let sdoMap = JSON.parse(`{"prod-uZn3IQfi":{"Evaluation":{"clause":"13.3.10.1","ids":["prod-4N8EtSSM"]}},"prod-WqUZkrPx":{"Evaluation":{"clause":"13.3.10.1","ids":["prod-E9lFAjcF"]}},"prod-WzAgO-V_":{"ModuleRequests":{"clause":"16.1.1.3","ids":["prod-Fii3Jv-w"]},"ImportEntries":{"clause":"16.2.1","ids":["prod-4FL2ok6-"]}},"prod-gQ0CVk3C":{"ModuleRequests":{"clause":"16.1.1.3","ids":["prod-eGLun9tY"]},"ImportEntries":{"clause":"16.2.1","ids":["prod-aTBBdt4A"]}},"prod-hjv695N2":{"ModuleRequests":{"clause":"16.1.1.3","ids":["prod-geKEXfWi"]}},"prod-CDGJVPkq":{"ImportEntries":{"clause":"16.2.1","ids":["prod--ST7ch2j"]}}}`);
-let biblio = JSON.parse(`{"refsByClause":{"sec-ContinueDynamicImport":["_ref_0","_ref_15"],"sec-abstract-module-records":["_ref_1","_ref_2","_ref_3","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41"],"sec-cyclic-module-records":["_ref_4","_ref_5","_ref_42","_ref_43","_ref_44","_ref_45","_ref_46","_ref_47","_ref_48","_ref_49","_ref_132"],"sec-module-semantics":["_ref_6","_ref_7","_ref_91","_ref_92","_ref_93","_ref_94","_ref_133","_ref_134"],"sec-HostLoadImportedModule":["_ref_8","_ref_95","_ref_96","_ref_97","_ref_98","_ref_99","_ref_100","_ref_101","_ref_102","_ref_103"],"sec-host-defined-fields-summary":["_ref_9","_ref_121"],"sec-import-call-runtime-semantics-evaluation":["_ref_10","_ref_11","_ref_12"],"sec-evaluate-import-call":["_ref_13","_ref_14"],"sec-modulerequest-record":["_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23"],"sec-static-semantics-modulerequests":["_ref_24","_ref_25","_ref_26","_ref_27","_ref_28","_ref_29","_ref_30","_ref_31","_ref_32","_ref_33","_ref_34","_ref_122","_ref_123","_ref_124","_ref_125","_ref_126","_ref_127","_ref_128","_ref_129","_ref_130","_ref_131"],"sec-LoadRequestedModules":["_ref_50","_ref_51","_ref_52","_ref_53"],"sec-InnerModuleLoading":["_ref_54","_ref_55","_ref_56","_ref_57","_ref_58","_ref_59","_ref_60","_ref_61","_ref_62"],"sec-ContinueModuleLoading":["_ref_63","_ref_64","_ref_65"],"sec-moduledeclarationlinking":["_ref_66","_ref_67"],"sec-InnerModuleLinking":["_ref_68","_ref_69","_ref_70","_ref_71","_ref_72","_ref_73","_ref_74","_ref_75"],"sec-moduleevaluation":["_ref_76","_ref_77"],"sec-innermoduleevaluation":["_ref_78","_ref_79","_ref_80","_ref_81","_ref_82","_ref_83","_ref_84","_ref_85","_ref_86"],"sec-getmodulesource":["_ref_87","_ref_88"],"sec-source-text-module-record-initialize-environment":["_ref_89","_ref_90"],"sec-FinishLoadingImportedModule":["_ref_104","_ref_105","_ref_106","_ref_107","_ref_108"],"sec-static-semantics-importentries":["_ref_109","_ref_110","_ref_111","_ref_112","_ref_113","_ref_157","_ref_158","_ref_159","_ref_160","_ref_161","_ref_162","_ref_163","_ref_164"],"sec-module-source-objects":["_ref_114"],"sec-properties-of-the-%abstractmodulesource%-intrinsic-object":["_ref_115"],"sec-%abstractmodulesource%.prototype":["_ref_116","_ref_117"],"sec-%abstractmodulesource%.prototype.constructor":["_ref_118","_ref_119"],"sec-get-%abstractmodulesource%.prototype.@@tostringtag":["_ref_120"],"sec-imports":["_ref_135","_ref_136","_ref_137","_ref_138","_ref_139","_ref_140","_ref_141","_ref_142","_ref_143","_ref_144","_ref_145","_ref_146","_ref_147","_ref_148","_ref_149","_ref_150","_ref_151","_ref_152","_ref_153","_ref_154","_ref_155","_ref_156"]},"entries":[{"type":"production","id":"prod-ImportCall","name":"ImportCall"},{"type":"clause","id":"sec-import-call-runtime-semantics-evaluation","titleHTML":"Runtime Semantics: Evaluation","number":"13.3.10.1"},{"type":"op","aoid":"ContinueDynamicImport","refId":"sec-ContinueDynamicImport"},{"type":"clause","id":"sec-ContinueDynamicImport","title":"ContinueDynamicImport ( promiseCapability, phase, moduleCompletion )","titleHTML":"ContinueDynamicImport ( <var>promiseCapability</var>, <ins><var>phase</var></ins>, <var>moduleCompletion</var> )","number":"13.3.10.2.1","referencingIds":["_ref_108"]},{"type":"op","aoid":"EvaluateImportCall","refId":"sec-evaluate-import-call"},{"type":"clause","id":"sec-evaluate-import-call","title":"EvaluateImportCall ( specifierExpression, phase )","titleHTML":"<ins>EvaluateImportCall ( <var>specifierExpression</var>, <var>phase</var> )</ins>","number":"13.3.10.2","referencingIds":["_ref_10","_ref_12"]},{"type":"clause","id":"sec-import-calls","titleHTML":"Import Calls","number":"13.3.10","referencingIds":["_ref_0","_ref_8"]},{"type":"clause","id":"sec-left-hand-side-expressions","titleHTML":"Left-Hand-Side Expressions","number":"13.3"},{"type":"clause","id":"sec-ecmascript-language-expressions","titleHTML":"ECMAScript Language: Expressions","number":"13"},{"type":"term","term":"ModuleRequest Record","id":"modulerequest-record","referencingIds":["_ref_13","_ref_16","_ref_17","_ref_19","_ref_21","_ref_23","_ref_24","_ref_28","_ref_29","_ref_31","_ref_32","_ref_34","_ref_47","_ref_56","_ref_71","_ref_82","_ref_96","_ref_105"]},{"type":"table","id":"table-modulerequest-record-fields","number":1,"caption":"Table 1: ModuleRequest Record fields"},{"type":"clause","id":"sec-modulerequest-record","title":"ModuleRequest Records","titleHTML":"<ins>ModuleRequest Records</ins>","number":"16.1.1.1"},{"type":"op","aoid":"ModuleRequests","refId":"sec-static-semantics-modulerequests"},{"type":"clause","id":"sec-static-semantics-modulerequests","titleHTML":"Static Semantics: ModuleRequests","number":"16.1.1.3","referencingIds":["_ref_18","_ref_25","_ref_26","_ref_27","_ref_30","_ref_33","_ref_112"]},{"type":"term","term":"Module Record","refId":"sec-abstract-module-records"},{"type":"table","id":"table-module-record-fields","number":2,"caption":"Table 2: Module Record Fields","referencingIds":["_ref_1","_ref_4","_ref_9"]},{"type":"table","id":"table-abstract-methods-of-module-records","number":3,"caption":"Table 3: Abstract Methods of Module Records","referencingIds":["_ref_2"]},{"type":"term","term":"ResolvedBinding Record","id":"resolvedbinding-record","referencingIds":["_ref_89"]},{"type":"clause","id":"sec-abstract-module-records","titleHTML":"Abstract Module Records","number":"16.1.1.4","referencingIds":["_ref_15","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_43","_ref_51","_ref_54","_ref_63","_ref_68","_ref_75","_ref_78","_ref_86","_ref_98","_ref_102","_ref_103","_ref_106","_ref_121"]},{"type":"term","term":"Cyclic Module Record","id":"cyclic-module-record","referencingIds":["_ref_22","_ref_35","_ref_42","_ref_44","_ref_45","_ref_46","_ref_48","_ref_49","_ref_50","_ref_55","_ref_62","_ref_66","_ref_69","_ref_70","_ref_73","_ref_74","_ref_76","_ref_79","_ref_81","_ref_84","_ref_85","_ref_87","_ref_88","_ref_95","_ref_104"]},{"type":"table","id":"table-cyclic-module-fields","number":4,"caption":"Table 4: Additional Fields of Cyclic Module Records","referencingIds":["_ref_5"]},{"type":"op","aoid":"InnerModuleLoading","refId":"sec-InnerModuleLoading"},{"type":"clause","id":"sec-InnerModuleLoading","title":"InnerModuleLoading ( state, module, phase )","titleHTML":"InnerModuleLoading ( <var>state</var>, <var>module</var>, <ins><var>phase</var></ins> )","number":"16.1.1.5.1.1","referencingIds":["_ref_52","_ref_57","_ref_65"]},{"type":"op","aoid":"ContinueModuleLoading","refId":"sec-ContinueModuleLoading"},{"type":"clause","id":"sec-ContinueModuleLoading","title":"ContinueModuleLoading ( state, phase, moduleCompletion )","titleHTML":"ContinueModuleLoading ( <var>state</var>, <ins><var>phase</var></ins>, <var>moduleCompletion</var> )","number":"16.1.1.5.1.2","referencingIds":["_ref_61","_ref_107"]},{"type":"clause","id":"sec-LoadRequestedModules","title":"LoadRequestedModules ( [ hostDefined ] )","titleHTML":"LoadRequestedModules ( [ <var>hostDefined</var> ] )","number":"16.1.1.5.1"},{"type":"op","aoid":"InnerModuleLinking","refId":"sec-InnerModuleLinking"},{"type":"clause","id":"sec-InnerModuleLinking","title":"InnerModuleLinking ( module, stack, index )","titleHTML":"InnerModuleLinking ( <var>module</var>, <var>stack</var>, <var>index</var> )","number":"16.1.1.5.2.1","referencingIds":["_ref_67","_ref_72","_ref_80"]},{"type":"clause","id":"sec-moduledeclarationlinking","titleHTML":"Link ( )","number":"16.1.1.5.2"},{"type":"op","aoid":"InnerModuleEvaluation","refId":"sec-innermoduleevaluation"},{"type":"clause","id":"sec-innermoduleevaluation","title":"InnerModuleEvaluation ( module, stack, index )","titleHTML":"InnerModuleEvaluation ( <var>module</var>, <var>stack</var>, <var>index</var> )","number":"16.1.1.5.3.1","referencingIds":["_ref_77","_ref_83"]},{"type":"clause","id":"sec-moduleevaluation","titleHTML":"Evaluate ( )","number":"16.1.1.5.3"},{"type":"clause","id":"sec-getmodulesource","title":"GetModuleSource ( )","titleHTML":"<ins>GetModuleSource ( )</ins>","number":"16.1.1.5.4"},{"type":"clause","id":"sec-cyclic-module-records","titleHTML":"Cyclic Module Records","number":"16.1.1.5"},{"type":"clause","id":"sec-source-text-module-record-initialize-environment","titleHTML":"InitializeEnvironment ( )","number":"16.1.1.6.1"},{"type":"clause","id":"sec-source-text-module-records","titleHTML":"Source Text Module Records","number":"16.1.1.6"},{"type":"term","term":"ImportEntry Record","id":"importentry-record","referencingIds":["_ref_90","_ref_91","_ref_92","_ref_93","_ref_94","_ref_109","_ref_113"]},{"type":"table","id":"table-importentry-record-fields","number":5,"caption":"Table 5: ImportEntry Record Fields","referencingIds":["_ref_6"]},{"type":"table","id":"table-import-forms-mapping-to-importentry-records","number":6,"caption":"Table 6 (Informative): Import Forms Mappings to ImportEntry Records","referencingIds":["_ref_7"]},{"type":"note","id":"note-HostLoadImportedModule-referrer-Realm-Record","number":1},{"type":"op","aoid":"HostLoadImportedModule","refId":"sec-HostLoadImportedModule"},{"type":"clause","id":"sec-HostLoadImportedModule","title":"HostLoadImportedModule ( referrer, specifier, moduleRequest, hostDefined, payload )","titleHTML":"HostLoadImportedModule ( <var>referrer</var>, <del><var>specifier</var></del>, <ins><var>moduleRequest</var></ins>, <var>hostDefined</var>, <var>payload</var> )","number":"16.1.1.7","referencingIds":["_ref_11","_ref_14","_ref_53","_ref_58","_ref_59","_ref_64"]},{"type":"op","aoid":"FinishLoadingImportedModule","refId":"sec-FinishLoadingImportedModule"},{"type":"clause","id":"sec-FinishLoadingImportedModule","title":"FinishLoadingImportedModule ( referrer, specifier, moduleRequest, payload, result )","titleHTML":"FinishLoadingImportedModule ( <var>referrer</var>, <del><var>specifier</var></del>, <ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var> )","number":"16.1.1.8","referencingIds":["_ref_60","_ref_97","_ref_99","_ref_100","_ref_101"]},{"type":"clause","id":"sec-module-semantics","titleHTML":"Module Semantics","number":"16.1.1"},{"type":"clause","id":"sec-modules","titleHTML":"Modules","number":"16.1"},{"type":"production","id":"prod-ImportDeclaration","name":"ImportDeclaration","referencingIds":["_ref_134"]},{"type":"production","id":"prod-ImportClause","name":"ImportClause","referencingIds":["_ref_122","_ref_135","_ref_157","_ref_160"]},{"type":"production","id":"prod-ImportedDefaultBinding","name":"ImportedDefaultBinding","referencingIds":["_ref_140","_ref_143","_ref_145"]},{"type":"production","id":"prod-NameSpaceImport","name":"NameSpaceImport","referencingIds":["_ref_141","_ref_144"]},{"type":"production","id":"prod-NamedImports","name":"NamedImports","referencingIds":["_ref_142","_ref_146"]},{"type":"production","id":"prod-FromClause","name":"FromClause","referencingIds":["_ref_123","_ref_124","_ref_125","_ref_127","_ref_128","_ref_129","_ref_130","_ref_131","_ref_136","_ref_139","_ref_158","_ref_159","_ref_163"]},{"type":"production","id":"prod-ImportsList","name":"ImportsList","referencingIds":["_ref_149","_ref_150","_ref_153"]},{"type":"production","id":"prod-ImportSpecifier","name":"ImportSpecifier","referencingIds":["_ref_152","_ref_154"]},{"type":"production","id":"prod-ModuleSpecifier","name":"ModuleSpecifier","referencingIds":["_ref_132","_ref_133","_ref_137","_ref_151","_ref_161"]},{"type":"production","id":"prod-ImportedBinding","name":"ImportedBinding","referencingIds":["_ref_126","_ref_138","_ref_147","_ref_148","_ref_155","_ref_156","_ref_162","_ref_164"]},{"type":"op","aoid":"ImportEntries","refId":"sec-static-semantics-importentries"},{"type":"clause","id":"sec-static-semantics-importentries","titleHTML":"Static Semantics: ImportEntries ( )","number":"16.2.1","referencingIds":["_ref_20","_ref_110","_ref_111"]},{"type":"clause","id":"sec-imports","titleHTML":"Imports","number":"16.2"},{"type":"clause","id":"sec-ecmascript-language-scripts-and-modules","titleHTML":"ECMAScript Language: Scripts and Modules","number":"16"},{"type":"term","term":"%AbstractModuleSource%","refId":"sec-%abstractmodulesource%-constructor"},{"type":"clause","id":"sec-%abstractmodulesource%","titleHTML":"%AbstractModuleSource% ( )","number":"28.1.1.1"},{"type":"clause","id":"sec-%abstractmodulesource%-constructor","titleHTML":"The %AbstractModuleSource% Constructor","number":"28.1.1","referencingIds":["_ref_41","_ref_114","_ref_115","_ref_116","_ref_118","_ref_119","_ref_120"]},{"type":"clause","id":"sec-%abstractmodulesource%.prototype","titleHTML":"%AbstractModuleSource%.prototype","number":"28.1.2.1"},{"type":"clause","id":"sec-properties-of-the-%abstractmodulesource%-intrinsic-object","titleHTML":"Properties of the %AbstractModuleSource% Intrinsic Object","number":"28.1.2"},{"type":"term","term":"%AbstractModuleSource% prototype object","refId":"sec-properties-of-the-%abstractmodulesource%-prototype-object"},{"type":"term","term":"%AbstractModuleSource.prototype%","refId":"sec-properties-of-the-%abstractmodulesource%-prototype-object"},{"type":"clause","id":"sec-%abstractmodulesource%.prototype.constructor","titleHTML":"%AbstractModuleSource%.prototype.constructor","number":"28.1.3.1"},{"type":"clause","id":"sec-get-%abstractmodulesource%.prototype.@@tostringtag","titleHTML":"get %AbstractModuleSource%.prototype [ @@toStringTag ] ( )","number":"28.1.3.2"},{"type":"clause","id":"sec-properties-of-the-%abstractmodulesource%-prototype-object","titleHTML":"Properties of the %AbstractModuleSource% Prototype Object","number":"28.1.3","referencingIds":["_ref_117"]},{"type":"clause","id":"sec-module-source-objects","title":"Module Source Objects","titleHTML":"<ins>Module Source Objects</ins>","number":"28.1","referencingIds":["_ref_3"]},{"type":"clause","id":"sec-reflection","titleHTML":"Reflection","number":"28"},{"type":"clause","id":"sec-host-defined-fields-summary","titleHTML":"Host-defined Fields","number":"A.1"},{"type":"clause","id":"sec-host-layering-points","titleHTML":"Host Layering Points","number":"A"},{"type":"clause","id":"sec-copyright-and-software-license","title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"B"}]}`);
+let biblio = JSON.parse(`{"refsByClause":{"sec-well-known-intrinsic-objects":["_ref_0","_ref_1"],"sec-ContinueDynamicImport":["_ref_2","_ref_17"],"sec-abstract-module-records":["_ref_3","_ref_4","_ref_5","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43"],"sec-cyclic-module-records":["_ref_6","_ref_7","_ref_44","_ref_45","_ref_46","_ref_47","_ref_48","_ref_49","_ref_50","_ref_51","_ref_129"],"sec-module-semantics":["_ref_8","_ref_9","_ref_92","_ref_93","_ref_94","_ref_95","_ref_130","_ref_131"],"sec-HostLoadImportedModule":["_ref_10","_ref_96","_ref_97","_ref_98","_ref_99","_ref_100","_ref_101","_ref_102","_ref_103","_ref_104"],"sec-host-defined-fields-summary":["_ref_11","_ref_118"],"sec-import-call-runtime-semantics-evaluation":["_ref_12","_ref_13","_ref_14"],"sec-evaluate-import-call":["_ref_15","_ref_16"],"sec-modulerequest-record":["_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23","_ref_24","_ref_25"],"sec-static-semantics-modulerequests":["_ref_26","_ref_27","_ref_28","_ref_29","_ref_30","_ref_31","_ref_32","_ref_33","_ref_34","_ref_35","_ref_36","_ref_119","_ref_120","_ref_121","_ref_122","_ref_123","_ref_124","_ref_125","_ref_126","_ref_127","_ref_128"],"sec-LoadRequestedModules":["_ref_52","_ref_53","_ref_54","_ref_55","_ref_56"],"sec-InnerModuleLoading":["_ref_57","_ref_58","_ref_59","_ref_60","_ref_61","_ref_62","_ref_63","_ref_64","_ref_65"],"sec-ContinueModuleLoading":["_ref_66","_ref_67","_ref_68"],"sec-moduledeclarationlinking":["_ref_69","_ref_70"],"sec-InnerModuleLinking":["_ref_71","_ref_72","_ref_73","_ref_74","_ref_75","_ref_76","_ref_77","_ref_78"],"sec-moduleevaluation":["_ref_79","_ref_80"],"sec-innermoduleevaluation":["_ref_81","_ref_82","_ref_83","_ref_84","_ref_85","_ref_86","_ref_87","_ref_88","_ref_89"],"sec-source-text-module-record-initialize-environment":["_ref_90","_ref_91"],"sec-FinishLoadingImportedModule":["_ref_105","_ref_106","_ref_107","_ref_108","_ref_109"],"sec-static-semantics-importentries":["_ref_110","_ref_111","_ref_112","_ref_113","_ref_114","_ref_154","_ref_155","_ref_156","_ref_157","_ref_158","_ref_159","_ref_160","_ref_161","_ref_162"],"sec-%abstractmodulesource%.prototype":["_ref_115"],"sec-get-%abstractmodulesource%.prototype.@@tostringtag":["_ref_116","_ref_117"],"sec-imports":["_ref_132","_ref_133","_ref_134","_ref_135","_ref_136","_ref_137","_ref_138","_ref_139","_ref_140","_ref_141","_ref_142","_ref_143","_ref_144","_ref_145","_ref_146","_ref_147","_ref_148","_ref_149","_ref_150","_ref_151","_ref_152","_ref_153"]},"entries":[{"type":"table","id":"table-well-known-intrinsic-objects","number":1,"caption":"Table 1: Well-Known Intrinsic Objects","referencingIds":["_ref_0"]},{"type":"clause","id":"sec-well-known-intrinsic-objects","titleHTML":"Well-Known Intrinsic Objects","number":"1.1.1.1"},{"type":"clause","id":"sec-object-type","titleHTML":"Object Type","number":"1.1.1","referencingIds":["_ref_116","_ref_117"]},{"type":"clause","id":"sec-ecmascript-language-types","titleHTML":"ECMAScript Language Types","number":"1.1"},{"type":"op","aoid":"Type","refId":"sec-ecmascript-data-types-and-values"},{"type":"clause","id":"sec-ecmascript-data-types-and-values","titleHTML":"ECMAScript Data Types and Values","number":"1"},{"type":"production","id":"prod-ImportCall","name":"ImportCall"},{"type":"clause","id":"sec-import-call-runtime-semantics-evaluation","titleHTML":"Runtime Semantics: Evaluation","number":"13.3.10.1"},{"type":"op","aoid":"ContinueDynamicImport","refId":"sec-ContinueDynamicImport"},{"type":"clause","id":"sec-ContinueDynamicImport","title":"ContinueDynamicImport ( promiseCapability, phase, moduleCompletion )","titleHTML":"ContinueDynamicImport ( <var>promiseCapability</var>, <ins><var>phase</var></ins>, <var>moduleCompletion</var> )","number":"13.3.10.2.1","referencingIds":["_ref_109"]},{"type":"op","aoid":"EvaluateImportCall","refId":"sec-evaluate-import-call"},{"type":"clause","id":"sec-evaluate-import-call","title":"EvaluateImportCall ( specifierExpression, phase )","titleHTML":"<ins>EvaluateImportCall ( <var>specifierExpression</var>, <var>phase</var> )</ins>","number":"13.3.10.2","referencingIds":["_ref_13","_ref_14"]},{"type":"clause","id":"sec-import-calls","titleHTML":"Import Calls","number":"13.3.10","referencingIds":["_ref_2","_ref_10"]},{"type":"clause","id":"sec-left-hand-side-expressions","titleHTML":"Left-Hand-Side Expressions","number":"13.3"},{"type":"clause","id":"sec-ecmascript-language-expressions","titleHTML":"ECMAScript Language: Expressions","number":"13"},{"type":"term","term":"ModuleRequest Record","id":"modulerequest-record","referencingIds":["_ref_15","_ref_18","_ref_19","_ref_21","_ref_23","_ref_25","_ref_26","_ref_30","_ref_31","_ref_33","_ref_34","_ref_36","_ref_49","_ref_59","_ref_74","_ref_85","_ref_97","_ref_106"]},{"type":"table","id":"table-modulerequest-record-fields","number":2,"caption":"Table 2: ModuleRequest Record fields"},{"type":"clause","id":"sec-modulerequest-record","title":"ModuleRequest Records","titleHTML":"<ins>ModuleRequest Records</ins>","number":"16.1.1.1"},{"type":"op","aoid":"ModuleRequests","refId":"sec-static-semantics-modulerequests"},{"type":"clause","id":"sec-static-semantics-modulerequests","titleHTML":"Static Semantics: ModuleRequests","number":"16.1.1.3","referencingIds":["_ref_20","_ref_27","_ref_28","_ref_29","_ref_32","_ref_35","_ref_113"]},{"type":"term","term":"Module Record","refId":"sec-abstract-module-records"},{"type":"table","id":"table-module-record-fields","number":3,"caption":"Table 3: Module Record Fields","referencingIds":["_ref_3","_ref_6","_ref_11"]},{"type":"table","id":"table-abstract-methods-of-module-records","number":4,"caption":"Table 4: Abstract Methods of Module Records","referencingIds":["_ref_4"]},{"type":"term","term":"ResolvedBinding Record","id":"resolvedbinding-record","referencingIds":["_ref_90"]},{"type":"clause","id":"sec-abstract-module-records","titleHTML":"Abstract Module Records","number":"16.1.1.4","referencingIds":["_ref_17","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_45","_ref_53","_ref_57","_ref_66","_ref_71","_ref_78","_ref_81","_ref_89","_ref_99","_ref_103","_ref_104","_ref_107","_ref_118"]},{"type":"term","term":"Cyclic Module Record","id":"cyclic-module-record","referencingIds":["_ref_24","_ref_37","_ref_44","_ref_46","_ref_47","_ref_48","_ref_50","_ref_51","_ref_52","_ref_58","_ref_65","_ref_69","_ref_72","_ref_73","_ref_76","_ref_77","_ref_79","_ref_82","_ref_84","_ref_87","_ref_88","_ref_96","_ref_105"]},{"type":"table","id":"table-cyclic-module-fields","number":5,"caption":"Table 5: Additional Fields of Cyclic Module Records","referencingIds":["_ref_7"]},{"type":"op","aoid":"InnerModuleLoading","refId":"sec-InnerModuleLoading"},{"type":"clause","id":"sec-InnerModuleLoading","title":"InnerModuleLoading ( state, module, loadType )","titleHTML":"InnerModuleLoading ( <var>state</var>, <var>module</var>, <ins><var>loadType</var></ins> )","number":"16.1.1.5.1.1","referencingIds":["_ref_54","_ref_56","_ref_60","_ref_68"]},{"type":"op","aoid":"ContinueModuleLoading","refId":"sec-ContinueModuleLoading"},{"type":"clause","id":"sec-ContinueModuleLoading","title":"ContinueModuleLoading ( state, phase, moduleCompletion )","titleHTML":"ContinueModuleLoading ( <var>state</var>, <ins><var>phase</var></ins>, <var>moduleCompletion</var> )","number":"16.1.1.5.1.2","referencingIds":["_ref_64","_ref_108"]},{"type":"clause","id":"sec-LoadRequestedModules","title":"LoadRequestedModules ( [ hostDefined ] )","titleHTML":"LoadRequestedModules ( [ <var>hostDefined</var> ] )","number":"16.1.1.5.1"},{"type":"op","aoid":"InnerModuleLinking","refId":"sec-InnerModuleLinking"},{"type":"clause","id":"sec-InnerModuleLinking","title":"InnerModuleLinking ( module, stack, index )","titleHTML":"InnerModuleLinking ( <var>module</var>, <var>stack</var>, <var>index</var> )","number":"16.1.1.5.2.1","referencingIds":["_ref_70","_ref_75","_ref_83"]},{"type":"clause","id":"sec-moduledeclarationlinking","titleHTML":"Link ( )","number":"16.1.1.5.2"},{"type":"op","aoid":"InnerModuleEvaluation","refId":"sec-innermoduleevaluation"},{"type":"clause","id":"sec-innermoduleevaluation","title":"InnerModuleEvaluation ( module, stack, index )","titleHTML":"InnerModuleEvaluation ( <var>module</var>, <var>stack</var>, <var>index</var> )","number":"16.1.1.5.3.1","referencingIds":["_ref_80","_ref_86"]},{"type":"clause","id":"sec-moduleevaluation","titleHTML":"Evaluate ( )","number":"16.1.1.5.3"},{"type":"clause","id":"sec-cyclic-module-records","titleHTML":"Cyclic Module Records","number":"16.1.1.5"},{"type":"clause","id":"sec-source-text-module-record-getmodulesource","title":"GetModuleSource ( )","titleHTML":"<ins>GetModuleSource ( )</ins>","number":"16.1.1.6.1"},{"type":"clause","id":"sec-source-text-module-record-initialize-environment","titleHTML":"InitializeEnvironment ( )","number":"16.1.1.6.2"},{"type":"clause","id":"sec-source-text-module-records","titleHTML":"Source Text Module Records","number":"16.1.1.6"},{"type":"term","term":"ImportEntry Record","id":"importentry-record","referencingIds":["_ref_91","_ref_92","_ref_93","_ref_94","_ref_95","_ref_110","_ref_114"]},{"type":"table","id":"table-importentry-record-fields","number":6,"caption":"Table 6: ImportEntry Record Fields","referencingIds":["_ref_8"]},{"type":"table","id":"table-import-forms-mapping-to-importentry-records","number":7,"caption":"Table 7 (Informative): Import Forms Mappings to ImportEntry Records","referencingIds":["_ref_9"]},{"type":"note","id":"note-HostLoadImportedModule-referrer-Realm-Record","number":1},{"type":"op","aoid":"HostLoadImportedModule","refId":"sec-HostLoadImportedModule"},{"type":"clause","id":"sec-HostLoadImportedModule","title":"HostLoadImportedModule ( referrer, specifier, moduleRequest, hostDefined, payload )","titleHTML":"HostLoadImportedModule ( <var>referrer</var>, <del><var>specifier</var></del>, <ins><var>moduleRequest</var></ins>, <var>hostDefined</var>, <var>payload</var> )","number":"16.1.1.7","referencingIds":["_ref_12","_ref_16","_ref_55","_ref_61","_ref_62","_ref_67"]},{"type":"op","aoid":"FinishLoadingImportedModule","refId":"sec-FinishLoadingImportedModule"},{"type":"clause","id":"sec-FinishLoadingImportedModule","title":"FinishLoadingImportedModule ( referrer, specifier, moduleRequest, payload, result )","titleHTML":"FinishLoadingImportedModule ( <var>referrer</var>, <del><var>specifier</var></del>, <ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var> )","number":"16.1.1.8","referencingIds":["_ref_63","_ref_98","_ref_100","_ref_101","_ref_102"]},{"type":"clause","id":"sec-module-semantics","titleHTML":"Module Semantics","number":"16.1.1"},{"type":"clause","id":"sec-modules","titleHTML":"Modules","number":"16.1"},{"type":"production","id":"prod-ImportDeclaration","name":"ImportDeclaration","referencingIds":["_ref_131"]},{"type":"production","id":"prod-ImportClause","name":"ImportClause","referencingIds":["_ref_119","_ref_132","_ref_154","_ref_157"]},{"type":"production","id":"prod-ImportedDefaultBinding","name":"ImportedDefaultBinding","referencingIds":["_ref_137","_ref_140","_ref_142"]},{"type":"production","id":"prod-NameSpaceImport","name":"NameSpaceImport","referencingIds":["_ref_138","_ref_141"]},{"type":"production","id":"prod-NamedImports","name":"NamedImports","referencingIds":["_ref_139","_ref_143"]},{"type":"production","id":"prod-FromClause","name":"FromClause","referencingIds":["_ref_120","_ref_121","_ref_122","_ref_124","_ref_125","_ref_126","_ref_127","_ref_128","_ref_133","_ref_136","_ref_155","_ref_156","_ref_160","_ref_161"]},{"type":"production","id":"prod-ImportsList","name":"ImportsList","referencingIds":["_ref_146","_ref_147","_ref_150"]},{"type":"production","id":"prod-ImportSpecifier","name":"ImportSpecifier","referencingIds":["_ref_149","_ref_151"]},{"type":"production","id":"prod-ModuleSpecifier","name":"ModuleSpecifier","referencingIds":["_ref_129","_ref_130","_ref_134","_ref_148","_ref_158"]},{"type":"production","id":"prod-ImportedBinding","name":"ImportedBinding","referencingIds":["_ref_123","_ref_135","_ref_144","_ref_145","_ref_152","_ref_153","_ref_159","_ref_162"]},{"type":"op","aoid":"ImportEntries","refId":"sec-static-semantics-importentries"},{"type":"clause","id":"sec-static-semantics-importentries","titleHTML":"Static Semantics: ImportEntries ( )","number":"16.2.1","referencingIds":["_ref_22","_ref_111","_ref_112"]},{"type":"clause","id":"sec-imports","titleHTML":"Imports","number":"16.2"},{"type":"clause","id":"sec-ecmascript-language-scripts-and-modules","titleHTML":"ECMAScript Language: Scripts and Modules","number":"16"},{"type":"clause","id":"sec-%abstractmodulesource%","titleHTML":"%AbstractModuleSource% ( )","number":"28.1.1.1"},{"type":"clause","id":"sec-%abstractmodulesource%-constructor","titleHTML":"The %AbstractModuleSource% Constructor","number":"28.1.1","referencingIds":["_ref_1"]},{"type":"clause","id":"sec-%abstractmodulesource%.prototype","titleHTML":"%AbstractModuleSource%.prototype","number":"28.1.2.1"},{"type":"clause","id":"sec-properties-of-the-%abstractmodulesource%-intrinsic-object","titleHTML":"Properties of the %AbstractModuleSource% Intrinsic Object","number":"28.1.2"},{"type":"term","term":"%AbstractModuleSource% prototype object","refId":"sec-properties-of-the-%abstractmodulesource%-prototype-object"},{"type":"term","term":"%AbstractModuleSource.prototype%","refId":"sec-properties-of-the-%abstractmodulesource%-prototype-object"},{"type":"clause","id":"sec-%abstractmodulesource%.prototype.constructor","titleHTML":"%AbstractModuleSource%.prototype.constructor","number":"28.1.3.1"},{"type":"clause","id":"sec-get-%abstractmodulesource%.prototype.@@tostringtag","titleHTML":"get %AbstractModuleSource%.prototype [ @@toStringTag ]","number":"28.1.3.2"},{"type":"clause","id":"sec-properties-of-the-%abstractmodulesource%-prototype-object","titleHTML":"Properties of the %AbstractModuleSource% Prototype Object","number":"28.1.3","referencingIds":["_ref_115"]},{"type":"clause","id":"sec-module-source-objects","title":"Module Source Objects","titleHTML":"<ins>Module Source Objects</ins>","number":"28.1","referencingIds":["_ref_5"]},{"type":"clause","id":"sec-reflection","titleHTML":"Reflection","number":"28"},{"type":"clause","id":"sec-host-defined-fields-summary","titleHTML":"Host-defined Fields","number":"A.1"},{"type":"clause","id":"sec-host-layering-points","titleHTML":"Host Layering Points","number":"A"},{"type":"clause","id":"sec-copyright-and-software-license","title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"B"}]}`);
 ;let usesMultipage = false</script><style>body {
   display: flex;
   word-wrap: break-word;
@@ -2525,7 +2525,793 @@ li.menu-search-result-term:before {
 </ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
       <title>Menu</title>
       <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
-    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-ecmascript-language-expressions" title="ECMAScript Language: Expressions"><span class="secnum">13</span> ECMAScript Language: Expressions</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-left-hand-side-expressions" title="Left-Hand-Side Expressions"><span class="secnum">13.3</span> Left-Hand-Side Expressions</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-import-calls" title="Import Calls"><span class="secnum">13.3.10</span> Import Calls</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-import-call-runtime-semantics-evaluation" title="Runtime Semantics: Evaluation"><span class="secnum">13.3.10.1</span> RS: Evaluation</a></li><li><span class="item-toggle">◢</span><a href="#sec-evaluate-import-call" title="EvaluateImportCall ( specifierExpression, phase )"><span class="secnum">13.3.10.2</span> <ins>EvaluateImportCall ( <var>specifierExpression</var>, <var>phase</var> )</ins></a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-ContinueDynamicImport" title="ContinueDynamicImport ( promiseCapability, phase, moduleCompletion )"><span class="secnum">13.3.10.2.1</span> ContinueDynamicImport ( <var>promiseCapability</var>, <ins><var>phase</var></ins>, <var>moduleCompletion</var> )</a></li></ol></li></ol></li></ol></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-ecmascript-language-scripts-and-modules" title="ECMAScript Language: Scripts and Modules"><span class="secnum">16</span> ECMAScript Language: Scripts and Modules</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-modules" title="Modules"><span class="secnum">16.1</span> Modules</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-module-semantics" title="Module Semantics"><span class="secnum">16.1.1</span> Module Semantics</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-modulerequest-record" title="ModuleRequest Records"><span class="secnum">16.1.1.1</span> <ins>ModuleRequest Records</ins></a></li><li><span class="item-toggle-none"></span><a href="#sec-static-semantics-modulerequests" title="Static Semantics: ModuleRequests"><span class="secnum">16.1.1.3</span> SS: ModuleRequests</a></li><li><span class="item-toggle-none"></span><a href="#sec-abstract-module-records" title="Abstract Module Records"><span class="secnum">16.1.1.4</span> Abstract Module Records</a></li><li><span class="item-toggle">◢</span><a href="#sec-cyclic-module-records" title="Cyclic Module Records"><span class="secnum">16.1.1.5</span> Cyclic Module Records</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-LoadRequestedModules" title="LoadRequestedModules ( [ hostDefined ] )"><span class="secnum">16.1.1.5.1</span> LoadRequestedModules ( [ <var>hostDefined</var> ] )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-InnerModuleLoading" title="InnerModuleLoading ( state, module, phase )"><span class="secnum">16.1.1.5.1.1</span> InnerModuleLoading ( <var>state</var>, <var>module</var>, <ins><var>phase</var></ins> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-ContinueModuleLoading" title="ContinueModuleLoading ( state, phase, moduleCompletion )"><span class="secnum">16.1.1.5.1.2</span> ContinueModuleLoading ( <var>state</var>, <ins><var>phase</var></ins>, <var>moduleCompletion</var> )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-moduledeclarationlinking" title="Link ( )"><span class="secnum">16.1.1.5.2</span> Link ( )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-InnerModuleLinking" title="InnerModuleLinking ( module, stack, index )"><span class="secnum">16.1.1.5.2.1</span> InnerModuleLinking ( <var>module</var>, <var>stack</var>, <var>index</var> )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-moduleevaluation" title="Evaluate ( )"><span class="secnum">16.1.1.5.3</span> Evaluate ( )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-innermoduleevaluation" title="InnerModuleEvaluation ( module, stack, index )"><span class="secnum">16.1.1.5.3.1</span> InnerModuleEvaluation ( <var>module</var>, <var>stack</var>, <var>index</var> )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-getmodulesource" title="GetModuleSource ( )"><span class="secnum">16.1.1.5.4</span> <ins>GetModuleSource ( )</ins></a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-source-text-module-records" title="Source Text Module Records"><span class="secnum">16.1.1.6</span> Source Text Module Records</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-source-text-module-record-initialize-environment" title="InitializeEnvironment ( )"><span class="secnum">16.1.1.6.1</span> InitializeEnvironment ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-HostLoadImportedModule" title="HostLoadImportedModule ( referrer, specifier, moduleRequest, hostDefined, payload )"><span class="secnum">16.1.1.7</span> HostLoadImportedModule ( <var>referrer</var>, <del><var>specifier</var></del>, <ins><var>moduleRequest</var></ins>, <var>hostDefined</var>, <var>payload</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-FinishLoadingImportedModule" title="FinishLoadingImportedModule ( referrer, specifier, moduleRequest, payload, result )"><span class="secnum">16.1.1.8</span> FinishLoadingImportedModule ( <var>referrer</var>, <del><var>specifier</var></del>, <ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var> )</a></li></ol></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-imports" title="Imports"><span class="secnum">16.2</span> Imports</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-static-semantics-importentries" title="Static Semantics: ImportEntries ( )"><span class="secnum">16.2.1</span> SS: ImportEntries ( )</a></li></ol></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-reflection" title="Reflection"><span class="secnum">28</span> Reflection</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-module-source-objects" title="Module Source Objects"><span class="secnum">28.1</span> <ins>Module Source Objects</ins></a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-%abstractmodulesource%-constructor" title="The %AbstractModuleSource% Constructor"><span class="secnum">28.1.1</span> The %AbstractModuleSource% Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-%abstractmodulesource%" title="%AbstractModuleSource% ( )"><span class="secnum">28.1.1.1</span> %AbstractModuleSource% ( )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-the-%abstractmodulesource%-intrinsic-object" title="Properties of the %AbstractModuleSource% Intrinsic Object"><span class="secnum">28.1.2</span> Properties of the %AbstractModuleSource% Intrinsic Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-%abstractmodulesource%.prototype" title="%AbstractModuleSource%.prototype"><span class="secnum">28.1.2.1</span> %AbstractModuleSource%.prototype</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-the-%abstractmodulesource%-prototype-object" title="Properties of the %AbstractModuleSource% Prototype Object"><span class="secnum">28.1.3</span> Properties of the %AbstractModuleSource% Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-%abstractmodulesource%.prototype.constructor" title="%AbstractModuleSource%.prototype.constructor"><span class="secnum">28.1.3.1</span> %AbstractModuleSource%.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-get-%abstractmodulesource%.prototype.@@tostringtag" title="get %AbstractModuleSource%.prototype [ @@toStringTag ] ( )"><span class="secnum">28.1.3.2</span> get %AbstractModuleSource%.prototype [ @@toStringTag ] ( )</a></li></ol></li></ol></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-host-layering-points" title="Host Layering Points"><span class="secnum">A</span> Host Layering Points</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-host-defined-fields-summary" title="Host-defined Fields"><span class="secnum">A.1</span> Host-defined Fields</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">B</span> Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Stage 2 Draft / April 7, 2024</h1><h1 class="title">Source Phase Imports</h1>
+    </svg></div><div id="menu-spacer" class="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-ecmascript-data-types-and-values" title="ECMAScript Data Types and Values"><span class="secnum">1</span> ECMAScript Data Types and Values</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-ecmascript-language-types" title="ECMAScript Language Types"><span class="secnum">1.1</span> ECMAScript Language Types</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-object-type" title="Object Type"><span class="secnum">1.1.1</span> Object Type</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-well-known-intrinsic-objects" title="Well-Known Intrinsic Objects"><span class="secnum">1.1.1.1</span> Well-Known Intrinsic Objects</a></li></ol></li></ol></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-ecmascript-language-expressions" title="ECMAScript Language: Expressions"><span class="secnum">13</span> ECMAScript Language: Expressions</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-left-hand-side-expressions" title="Left-Hand-Side Expressions"><span class="secnum">13.3</span> Left-Hand-Side Expressions</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-import-calls" title="Import Calls"><span class="secnum">13.3.10</span> Import Calls</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-import-call-runtime-semantics-evaluation" title="Runtime Semantics: Evaluation"><span class="secnum">13.3.10.1</span> RS: Evaluation</a></li><li><span class="item-toggle">◢</span><a href="#sec-evaluate-import-call" title="EvaluateImportCall ( specifierExpression, phase )"><span class="secnum">13.3.10.2</span> <ins>EvaluateImportCall ( <var>specifierExpression</var>, <var>phase</var> )</ins></a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-ContinueDynamicImport" title="ContinueDynamicImport ( promiseCapability, phase, moduleCompletion )"><span class="secnum">13.3.10.2.1</span> ContinueDynamicImport ( <var>promiseCapability</var>, <ins><var>phase</var></ins>, <var>moduleCompletion</var> )</a></li></ol></li></ol></li></ol></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-ecmascript-language-scripts-and-modules" title="ECMAScript Language: Scripts and Modules"><span class="secnum">16</span> ECMAScript Language: Scripts and Modules</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-modules" title="Modules"><span class="secnum">16.1</span> Modules</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-module-semantics" title="Module Semantics"><span class="secnum">16.1.1</span> Module Semantics</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-modulerequest-record" title="ModuleRequest Records"><span class="secnum">16.1.1.1</span> <ins>ModuleRequest Records</ins></a></li><li><span class="item-toggle-none"></span><a href="#sec-static-semantics-modulerequests" title="Static Semantics: ModuleRequests"><span class="secnum">16.1.1.3</span> SS: ModuleRequests</a></li><li><span class="item-toggle-none"></span><a href="#sec-abstract-module-records" title="Abstract Module Records"><span class="secnum">16.1.1.4</span> Abstract Module Records</a></li><li><span class="item-toggle">◢</span><a href="#sec-cyclic-module-records" title="Cyclic Module Records"><span class="secnum">16.1.1.5</span> Cyclic Module Records</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-LoadRequestedModules" title="LoadRequestedModules ( [ hostDefined ] )"><span class="secnum">16.1.1.5.1</span> LoadRequestedModules ( [ <var>hostDefined</var> ] )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-InnerModuleLoading" title="InnerModuleLoading ( state, module, loadType )"><span class="secnum">16.1.1.5.1.1</span> InnerModuleLoading ( <var>state</var>, <var>module</var>, <ins><var>loadType</var></ins> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-ContinueModuleLoading" title="ContinueModuleLoading ( state, phase, moduleCompletion )"><span class="secnum">16.1.1.5.1.2</span> ContinueModuleLoading ( <var>state</var>, <ins><var>phase</var></ins>, <var>moduleCompletion</var> )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-moduledeclarationlinking" title="Link ( )"><span class="secnum">16.1.1.5.2</span> Link ( )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-InnerModuleLinking" title="InnerModuleLinking ( module, stack, index )"><span class="secnum">16.1.1.5.2.1</span> InnerModuleLinking ( <var>module</var>, <var>stack</var>, <var>index</var> )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-moduleevaluation" title="Evaluate ( )"><span class="secnum">16.1.1.5.3</span> Evaluate ( )</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-innermoduleevaluation" title="InnerModuleEvaluation ( module, stack, index )"><span class="secnum">16.1.1.5.3.1</span> InnerModuleEvaluation ( <var>module</var>, <var>stack</var>, <var>index</var> )</a></li></ol></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-source-text-module-records" title="Source Text Module Records"><span class="secnum">16.1.1.6</span> Source Text Module Records</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-source-text-module-record-getmodulesource" title="GetModuleSource ( )"><span class="secnum">16.1.1.6.1</span> <ins>GetModuleSource ( )</ins></a></li><li><span class="item-toggle-none"></span><a href="#sec-source-text-module-record-initialize-environment" title="InitializeEnvironment ( )"><span class="secnum">16.1.1.6.2</span> InitializeEnvironment ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-HostLoadImportedModule" title="HostLoadImportedModule ( referrer, specifier, moduleRequest, hostDefined, payload )"><span class="secnum">16.1.1.7</span> HostLoadImportedModule ( <var>referrer</var>, <del><var>specifier</var></del>, <ins><var>moduleRequest</var></ins>, <var>hostDefined</var>, <var>payload</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-FinishLoadingImportedModule" title="FinishLoadingImportedModule ( referrer, specifier, moduleRequest, payload, result )"><span class="secnum">16.1.1.8</span> FinishLoadingImportedModule ( <var>referrer</var>, <del><var>specifier</var></del>, <ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var> )</a></li></ol></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-imports" title="Imports"><span class="secnum">16.2</span> Imports</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-static-semantics-importentries" title="Static Semantics: ImportEntries ( )"><span class="secnum">16.2.1</span> SS: ImportEntries ( )</a></li></ol></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-reflection" title="Reflection"><span class="secnum">28</span> Reflection</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-module-source-objects" title="Module Source Objects"><span class="secnum">28.1</span> <ins>Module Source Objects</ins></a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-%abstractmodulesource%-constructor" title="The %AbstractModuleSource% Constructor"><span class="secnum">28.1.1</span> The %AbstractModuleSource% Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-%abstractmodulesource%" title="%AbstractModuleSource% ( )"><span class="secnum">28.1.1.1</span> %AbstractModuleSource% ( )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-the-%abstractmodulesource%-intrinsic-object" title="Properties of the %AbstractModuleSource% Intrinsic Object"><span class="secnum">28.1.2</span> Properties of the %AbstractModuleSource% Intrinsic Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-%abstractmodulesource%.prototype" title="%AbstractModuleSource%.prototype"><span class="secnum">28.1.2.1</span> %AbstractModuleSource%.prototype</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-the-%abstractmodulesource%-prototype-object" title="Properties of the %AbstractModuleSource% Prototype Object"><span class="secnum">28.1.3</span> Properties of the %AbstractModuleSource% Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-%abstractmodulesource%.prototype.constructor" title="%AbstractModuleSource%.prototype.constructor"><span class="secnum">28.1.3.1</span> %AbstractModuleSource%.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-get-%abstractmodulesource%.prototype.@@tostringtag" title="get %AbstractModuleSource%.prototype [ @@toStringTag ]"><span class="secnum">28.1.3.2</span> get %AbstractModuleSource%.prototype [ @@toStringTag ]</a></li></ol></li></ol></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-host-layering-points" title="Host Layering Points"><span class="secnum">A</span> Host Layering Points</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-host-defined-fields-summary" title="Host-defined Fields"><span class="secnum">A.1</span> Host-defined Fields</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">B</span> Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Stage 3 Draft / April 7, 2024</h1><h1 class="title">Source Phase Imports</h1>
+
+<emu-clause id="sec-ecmascript-data-types-and-values" aoid="Type">
+  <h1><span class="secnum">1</span> ECMAScript Data Types and Values</h1>
+  <emu-clause id="sec-ecmascript-language-types">
+    <h1><span class="secnum">1.1</span> ECMAScript Language Types</h1>
+    <emu-clause id="sec-object-type">
+      <h1><span class="secnum">1.1.1</span> Object Type</h1>
+      <emu-clause id="sec-well-known-intrinsic-objects">
+        <h1><span class="secnum">1.1.1.1</span> Well-Known Intrinsic Objects</h1>
+        <p>Well-known intrinsics are built-in objects that are explicitly referenced by the algorithms of this specification and which usually have <emu-xref href="#realm"><a href="https://tc39.es/ecma262/#realm">realm</a></emu-xref>-specific identities. Unless otherwise specified each intrinsic object actually corresponds to a set of similar objects, one per <emu-xref href="#realm"><a href="https://tc39.es/ecma262/#realm">realm</a></emu-xref>.</p>
+        <p>Within this specification a reference such as %name% means the intrinsic object, associated with the current <emu-xref href="#realm"><a href="https://tc39.es/ecma262/#realm">realm</a></emu-xref>, corresponding to the name. A reference such as %name.a.b% means, as if the <emu-val>"b"</emu-val> property of the value of the <emu-val>"a"</emu-val> property of the intrinsic object %name% was accessed prior to any ECMAScript code being evaluated. Determination of the current <emu-xref href="#realm"><a href="https://tc39.es/ecma262/#realm">realm</a></emu-xref> and its intrinsics is described in <emu-xref href="#sec-execution-contexts"><a href="https://tc39.es/ecma262/#sec-execution-contexts">9.4</a></emu-xref>. The well-known intrinsics are listed in <emu-xref href="#table-well-known-intrinsic-objects" id="_ref_0"><a href="#table-well-known-intrinsic-objects">Table 1</a></emu-xref>.</p>
+        <emu-table id="table-well-known-intrinsic-objects" caption="Well-Known Intrinsic Objects" oldids="table-7"><figure><figcaption>Table 1: Well-Known Intrinsic Objects</figcaption><span id="table-7"></span>
+          <table>
+            <tbody><tr>
+              <th>
+                Intrinsic Name
+              </th>
+              <th>
+                Global Name
+              </th>
+              <th>
+                ECMAScript Language Association
+              </th>
+            </tr>
+            <tr>
+              <td>
+                %AbstractModuleSource%
+              </td>
+              <td>
+              </td>
+              <td>
+                The %AbstractModuleSource% <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-%abstractmodulesource%-constructor" id="_ref_1"><a href="#sec-%abstractmodulesource%-constructor">28.1.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-aggregate-error-constructor"><a href="https://tc39.es/ecma262/#sec-aggregate-error-constructor">%AggregateError%</a></emu-xref>
+              </td>
+              <td>
+                <code>AggregateError</code>
+              </td>
+              <td>
+                The <code>AggregateError</code> <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-aggregate-error-constructor"><a href="https://tc39.es/ecma262/#sec-aggregate-error-constructor">20.5.7.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-array-constructor"><a href="https://tc39.es/ecma262/#sec-array-constructor">%Array%</a></emu-xref>
+              </td>
+              <td>
+                <code>Array</code>
+              </td>
+              <td>
+                The Array <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-array-constructor"><a href="https://tc39.es/ecma262/#sec-array-constructor">23.1.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-arraybuffer-constructor"><a href="https://tc39.es/ecma262/#sec-arraybuffer-constructor">%ArrayBuffer%</a></emu-xref>
+              </td>
+              <td>
+                <code>ArrayBuffer</code>
+              </td>
+              <td>
+                The ArrayBuffer <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-arraybuffer-constructor"><a href="https://tc39.es/ecma262/#sec-arraybuffer-constructor">25.1.3</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-%arrayiteratorprototype%-object"><a href="https://tc39.es/ecma262/#sec-%arrayiteratorprototype%-object">%ArrayIteratorPrototype%</a></emu-xref>
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of Array iterator objects (<emu-xref href="#sec-array-iterator-objects"><a href="https://tc39.es/ecma262/#sec-array-iterator-objects">23.1.5</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-%asyncfromsynciteratorprototype%-object"><a href="https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%-object">%AsyncFromSyncIteratorPrototype%</a></emu-xref>
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of async-from-sync iterator objects (<emu-xref href="#sec-async-from-sync-iterator-objects"><a href="https://tc39.es/ecma262/#sec-async-from-sync-iterator-objects">27.1.4</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-async-function-constructor"><a href="https://tc39.es/ecma262/#sec-async-function-constructor">%AsyncFunction%</a></emu-xref>
+              </td>
+              <td>
+              </td>
+              <td>
+                The <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> of async <emu-xref href="#function-object"><a href="https://tc39.es/ecma262/#function-object">function objects</a></emu-xref> (<emu-xref href="#sec-async-function-constructor"><a href="https://tc39.es/ecma262/#sec-async-function-constructor">27.7.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-asyncgeneratorfunction-constructor"><a href="https://tc39.es/ecma262/#sec-asyncgeneratorfunction-constructor">%AsyncGeneratorFunction%</a></emu-xref>
+              </td>
+              <td>
+              </td>
+              <td>
+                The <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> of async generator <emu-xref href="#function-object"><a href="https://tc39.es/ecma262/#function-object">function objects</a></emu-xref> (<emu-xref href="#sec-asyncgeneratorfunction-constructor"><a href="https://tc39.es/ecma262/#sec-asyncgeneratorfunction-constructor">27.4.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %AsyncGeneratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of async generator objects (<emu-xref href="#sec-asyncgenerator-objects"><a href="https://tc39.es/ecma262/#sec-asyncgenerator-objects">27.6</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-asynciteratorprototype"><a href="https://tc39.es/ecma262/#sec-asynciteratorprototype">%AsyncIteratorPrototype%</a></emu-xref>
+              </td>
+              <td>
+              </td>
+              <td>
+                An object that all standard built-in async iterator objects indirectly inherit from
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-atomics-object"><a href="https://tc39.es/ecma262/#sec-atomics-object">%Atomics%</a></emu-xref>
+              </td>
+              <td>
+                <code>Atomics</code>
+              </td>
+              <td>
+                The <code>Atomics</code> object (<emu-xref href="#sec-atomics-object"><a href="https://tc39.es/ecma262/#sec-atomics-object">25.4</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-bigint-constructor"><a href="https://tc39.es/ecma262/#sec-bigint-constructor">%BigInt%</a></emu-xref>
+              </td>
+              <td>
+                <code>BigInt</code>
+              </td>
+              <td>
+                The BigInt <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-bigint-constructor"><a href="https://tc39.es/ecma262/#sec-bigint-constructor">21.2.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">%BigInt64Array%</a></emu-xref>
+              </td>
+              <td>
+                <code>BigInt64Array</code>
+              </td>
+              <td>
+                The BigInt64Array <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">23.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">%BigUint64Array%</a></emu-xref>
+              </td>
+              <td>
+                <code>BigUint64Array</code>
+              </td>
+              <td>
+                The BigUint64Array <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">23.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-boolean-constructor"><a href="https://tc39.es/ecma262/#sec-boolean-constructor">%Boolean%</a></emu-xref>
+              </td>
+              <td>
+                <code>Boolean</code>
+              </td>
+              <td>
+                The Boolean <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-boolean-constructor"><a href="https://tc39.es/ecma262/#sec-boolean-constructor">20.3.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-dataview-constructor"><a href="https://tc39.es/ecma262/#sec-dataview-constructor">%DataView%</a></emu-xref>
+              </td>
+              <td>
+                <code>DataView</code>
+              </td>
+              <td>
+                The DataView <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-dataview-constructor"><a href="https://tc39.es/ecma262/#sec-dataview-constructor">25.3.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-date-constructor"><a href="https://tc39.es/ecma262/#sec-date-constructor">%Date%</a></emu-xref>
+              </td>
+              <td>
+                <code>Date</code>
+              </td>
+              <td>
+                The Date <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-date-constructor"><a href="https://tc39.es/ecma262/#sec-date-constructor">21.4.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-decodeuri-encodeduri"><a href="https://tc39.es/ecma262/#sec-decodeuri-encodeduri">%decodeURI%</a></emu-xref>
+              </td>
+              <td>
+                <code>decodeURI</code>
+              </td>
+              <td>
+                The <code>decodeURI</code> function (<emu-xref href="#sec-decodeuri-encodeduri"><a href="https://tc39.es/ecma262/#sec-decodeuri-encodeduri">19.2.6.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-decodeuricomponent-encodeduricomponent"><a href="https://tc39.es/ecma262/#sec-decodeuricomponent-encodeduricomponent">%decodeURIComponent%</a></emu-xref>
+              </td>
+              <td>
+                <code>decodeURIComponent</code>
+              </td>
+              <td>
+                The <code>decodeURIComponent</code> function (<emu-xref href="#sec-decodeuricomponent-encodeduricomponent"><a href="https://tc39.es/ecma262/#sec-decodeuricomponent-encodeduricomponent">19.2.6.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-encodeuri-uri"><a href="https://tc39.es/ecma262/#sec-encodeuri-uri">%encodeURI%</a></emu-xref>
+              </td>
+              <td>
+                <code>encodeURI</code>
+              </td>
+              <td>
+                The <code>encodeURI</code> function (<emu-xref href="#sec-encodeuri-uri"><a href="https://tc39.es/ecma262/#sec-encodeuri-uri">19.2.6.3</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-encodeuricomponent-uricomponent"><a href="https://tc39.es/ecma262/#sec-encodeuricomponent-uricomponent">%encodeURIComponent%</a></emu-xref>
+              </td>
+              <td>
+                <code>encodeURIComponent</code>
+              </td>
+              <td>
+                The <code>encodeURIComponent</code> function (<emu-xref href="#sec-encodeuricomponent-uricomponent"><a href="https://tc39.es/ecma262/#sec-encodeuricomponent-uricomponent">19.2.6.4</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-error-constructor"><a href="https://tc39.es/ecma262/#sec-error-constructor">%Error%</a></emu-xref>
+              </td>
+              <td>
+                <code>Error</code>
+              </td>
+              <td>
+                The Error <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-error-constructor"><a href="https://tc39.es/ecma262/#sec-error-constructor">20.5.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-eval-x"><a href="https://tc39.es/ecma262/#sec-eval-x">%eval%</a></emu-xref>
+              </td>
+              <td>
+                <code>eval</code>
+              </td>
+              <td>
+                The <code>eval</code> function (<emu-xref href="#sec-eval-x"><a href="https://tc39.es/ecma262/#sec-eval-x">19.2.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-native-error-types-used-in-this-standard-evalerror"><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-evalerror">%EvalError%</a></emu-xref>
+              </td>
+              <td>
+                <code>EvalError</code>
+              </td>
+              <td>
+                The EvalError <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-native-error-types-used-in-this-standard-evalerror"><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-evalerror">20.5.5.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-finalization-registry-constructor"><a href="https://tc39.es/ecma262/#sec-finalization-registry-constructor">%FinalizationRegistry%</a></emu-xref>
+              </td>
+              <td>
+                <code>FinalizationRegistry</code>
+              </td>
+              <td>
+                The <emu-xref href="#sec-finalization-registry-constructor"><a href="https://tc39.es/ecma262/#sec-finalization-registry-constructor">FinalizationRegistry</a></emu-xref> <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-finalization-registry-constructor"><a href="https://tc39.es/ecma262/#sec-finalization-registry-constructor">26.2.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">%Float32Array%</a></emu-xref>
+              </td>
+              <td>
+                <code>Float32Array</code>
+              </td>
+              <td>
+                The Float32Array <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">23.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">%Float64Array%</a></emu-xref>
+              </td>
+              <td>
+                <code>Float64Array</code>
+              </td>
+              <td>
+                The Float64Array <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">23.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-%foriniteratorprototype%-object"><a href="https://tc39.es/ecma262/#sec-%foriniteratorprototype%-object">%ForInIteratorPrototype%</a></emu-xref>
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of For-In iterator objects (<emu-xref href="#sec-for-in-iterator-objects"><a href="https://tc39.es/ecma262/#sec-for-in-iterator-objects">14.7.5.10</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-function-constructor"><a href="https://tc39.es/ecma262/#sec-function-constructor">%Function%</a></emu-xref>
+              </td>
+              <td>
+                <code>Function</code>
+              </td>
+              <td>
+                The Function <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-function-constructor"><a href="https://tc39.es/ecma262/#sec-function-constructor">20.2.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-generatorfunction-constructor"><a href="https://tc39.es/ecma262/#sec-generatorfunction-constructor">%GeneratorFunction%</a></emu-xref>
+              </td>
+              <td>
+              </td>
+              <td>
+                The <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> of generator <emu-xref href="#function-object"><a href="https://tc39.es/ecma262/#function-object">function objects</a></emu-xref> (<emu-xref href="#sec-generatorfunction-constructor"><a href="https://tc39.es/ecma262/#sec-generatorfunction-constructor">27.3.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %GeneratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of generator objects (<emu-xref href="#sec-generator-objects"><a href="https://tc39.es/ecma262/#sec-generator-objects">27.5</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">%Int8Array%</a></emu-xref>
+              </td>
+              <td>
+                <code>Int8Array</code>
+              </td>
+              <td>
+                The Int8Array <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">23.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">%Int16Array%</a></emu-xref>
+              </td>
+              <td>
+                <code>Int16Array</code>
+              </td>
+              <td>
+                The Int16Array <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">23.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">%Int32Array%</a></emu-xref>
+              </td>
+              <td>
+                <code>Int32Array</code>
+              </td>
+              <td>
+                The Int32Array <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">23.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-isfinite-number"><a href="https://tc39.es/ecma262/#sec-isfinite-number">%isFinite%</a></emu-xref>
+              </td>
+              <td>
+                <code>isFinite</code>
+              </td>
+              <td>
+                The <code>isFinite</code> function (<emu-xref href="#sec-isfinite-number"><a href="https://tc39.es/ecma262/#sec-isfinite-number">19.2.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-isnan-number"><a href="https://tc39.es/ecma262/#sec-isnan-number">%isNaN%</a></emu-xref>
+              </td>
+              <td>
+                <code>isNaN</code>
+              </td>
+              <td>
+                The <code>isNaN</code> function (<emu-xref href="#sec-isnan-number"><a href="https://tc39.es/ecma262/#sec-isnan-number">19.2.3</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-%iteratorprototype%-object"><a href="https://tc39.es/ecma262/#sec-%iteratorprototype%-object">%IteratorPrototype%</a></emu-xref>
+              </td>
+              <td>
+              </td>
+              <td>
+                An object that all standard built-in iterator objects indirectly inherit from
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-json-object"><a href="https://tc39.es/ecma262/#sec-json-object">%JSON%</a></emu-xref>
+              </td>
+              <td>
+                <code>JSON</code>
+              </td>
+              <td>
+                The <code>JSON</code> object (<emu-xref href="#sec-json-object"><a href="https://tc39.es/ecma262/#sec-json-object">25.5</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-map-constructor"><a href="https://tc39.es/ecma262/#sec-map-constructor">%Map%</a></emu-xref>
+              </td>
+              <td>
+                <code>Map</code>
+              </td>
+              <td>
+                The Map <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-map-constructor"><a href="https://tc39.es/ecma262/#sec-map-constructor">24.1.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-%mapiteratorprototype%-object"><a href="https://tc39.es/ecma262/#sec-%mapiteratorprototype%-object">%MapIteratorPrototype%</a></emu-xref>
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of Map iterator objects (<emu-xref href="#sec-map-iterator-objects"><a href="https://tc39.es/ecma262/#sec-map-iterator-objects">24.1.5</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-math-object"><a href="https://tc39.es/ecma262/#sec-math-object">%Math%</a></emu-xref>
+              </td>
+              <td>
+                <code>Math</code>
+              </td>
+              <td>
+                The <code>Math</code> object (<emu-xref href="#sec-math-object"><a href="https://tc39.es/ecma262/#sec-math-object">21.3</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-number-constructor"><a href="https://tc39.es/ecma262/#sec-number-constructor">%Number%</a></emu-xref>
+              </td>
+              <td>
+                <code>Number</code>
+              </td>
+              <td>
+                The Number <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-number-constructor"><a href="https://tc39.es/ecma262/#sec-number-constructor">21.1.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-object-constructor"><a href="https://tc39.es/ecma262/#sec-object-constructor">%Object%</a></emu-xref>
+              </td>
+              <td>
+                <code>Object</code>
+              </td>
+              <td>
+                The Object <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-object-constructor"><a href="https://tc39.es/ecma262/#sec-object-constructor">20.1.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-parsefloat-string"><a href="https://tc39.es/ecma262/#sec-parsefloat-string">%parseFloat%</a></emu-xref>
+              </td>
+              <td>
+                <code>parseFloat</code>
+              </td>
+              <td>
+                The <code>parseFloat</code> function (<emu-xref href="#sec-parsefloat-string"><a href="https://tc39.es/ecma262/#sec-parsefloat-string">19.2.4</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-parseint-string-radix"><a href="https://tc39.es/ecma262/#sec-parseint-string-radix">%parseInt%</a></emu-xref>
+              </td>
+              <td>
+                <code>parseInt</code>
+              </td>
+              <td>
+                The <code>parseInt</code> function (<emu-xref href="#sec-parseint-string-radix"><a href="https://tc39.es/ecma262/#sec-parseint-string-radix">19.2.5</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-promise-constructor"><a href="https://tc39.es/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>
+              </td>
+              <td>
+                <code>Promise</code>
+              </td>
+              <td>
+                The Promise <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-promise-constructor"><a href="https://tc39.es/ecma262/#sec-promise-constructor">27.2.3</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-proxy-constructor"><a href="https://tc39.es/ecma262/#sec-proxy-constructor">%Proxy%</a></emu-xref>
+              </td>
+              <td>
+                <code>Proxy</code>
+              </td>
+              <td>
+                The Proxy <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-proxy-constructor"><a href="https://tc39.es/ecma262/#sec-proxy-constructor">28.2.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-native-error-types-used-in-this-standard-rangeerror"><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror">%RangeError%</a></emu-xref>
+              </td>
+              <td>
+                <code>RangeError</code>
+              </td>
+              <td>
+                The RangeError <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-native-error-types-used-in-this-standard-rangeerror"><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror">20.5.5.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-native-error-types-used-in-this-standard-referenceerror"><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-referenceerror">%ReferenceError%</a></emu-xref>
+              </td>
+              <td>
+                <code>ReferenceError</code>
+              </td>
+              <td>
+                The ReferenceError <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-native-error-types-used-in-this-standard-referenceerror"><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-referenceerror">20.5.5.3</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-reflect-object"><a href="https://tc39.es/ecma262/#sec-reflect-object">%Reflect%</a></emu-xref>
+              </td>
+              <td>
+                <code>Reflect</code>
+              </td>
+              <td>
+                The <code>Reflect</code> object (<emu-xref href="#sec-reflect-object"><a href="https://tc39.es/ecma262/#sec-reflect-object">28.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-regexp-constructor"><a href="https://tc39.es/ecma262/#sec-regexp-constructor">%RegExp%</a></emu-xref>
+              </td>
+              <td>
+                <code>RegExp</code>
+              </td>
+              <td>
+                The RegExp <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-regexp-constructor"><a href="https://tc39.es/ecma262/#sec-regexp-constructor">22.2.4</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-%regexpstringiteratorprototype%-object"><a href="https://tc39.es/ecma262/#sec-%regexpstringiteratorprototype%-object">%RegExpStringIteratorPrototype%</a></emu-xref>
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of RegExp String Iterator objects (<emu-xref href="#sec-regexp-string-iterator-objects"><a href="https://tc39.es/ecma262/#sec-regexp-string-iterator-objects">22.2.9</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-set-constructor"><a href="https://tc39.es/ecma262/#sec-set-constructor">%Set%</a></emu-xref>
+              </td>
+              <td>
+                <code>Set</code>
+              </td>
+              <td>
+                The Set <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-set-constructor"><a href="https://tc39.es/ecma262/#sec-set-constructor">24.2.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-%setiteratorprototype%-object"><a href="https://tc39.es/ecma262/#sec-%setiteratorprototype%-object">%SetIteratorPrototype%</a></emu-xref>
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of Set iterator objects (<emu-xref href="#sec-set-iterator-objects"><a href="https://tc39.es/ecma262/#sec-set-iterator-objects">24.2.5</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-sharedarraybuffer-constructor"><a href="https://tc39.es/ecma262/#sec-sharedarraybuffer-constructor">%SharedArrayBuffer%</a></emu-xref>
+              </td>
+              <td>
+                <code>SharedArrayBuffer</code>
+              </td>
+              <td>
+                The SharedArrayBuffer <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-sharedarraybuffer-constructor"><a href="https://tc39.es/ecma262/#sec-sharedarraybuffer-constructor">25.2.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-string-constructor"><a href="https://tc39.es/ecma262/#sec-string-constructor">%String%</a></emu-xref>
+              </td>
+              <td>
+                <code>String</code>
+              </td>
+              <td>
+                The String <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-string-constructor"><a href="https://tc39.es/ecma262/#sec-string-constructor">22.1.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-%stringiteratorprototype%-object"><a href="https://tc39.es/ecma262/#sec-%stringiteratorprototype%-object">%StringIteratorPrototype%</a></emu-xref>
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of String iterator objects (<emu-xref href="#sec-string-iterator-objects"><a href="https://tc39.es/ecma262/#sec-string-iterator-objects">22.1.5</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-symbol-constructor"><a href="https://tc39.es/ecma262/#sec-symbol-constructor">%Symbol%</a></emu-xref>
+              </td>
+              <td>
+                <code>Symbol</code>
+              </td>
+              <td>
+                The Symbol <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-symbol-constructor"><a href="https://tc39.es/ecma262/#sec-symbol-constructor">20.4.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-native-error-types-used-in-this-standard-syntaxerror"><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-syntaxerror">%SyntaxError%</a></emu-xref>
+              </td>
+              <td>
+                <code>SyntaxError</code>
+              </td>
+              <td>
+                The SyntaxError <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-native-error-types-used-in-this-standard-syntaxerror"><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-syntaxerror">20.5.5.4</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-%throwtypeerror%"><a href="https://tc39.es/ecma262/#sec-%throwtypeerror%">%ThrowTypeError%</a></emu-xref>
+              </td>
+              <td>
+              </td>
+              <td>
+                A <emu-xref href="#function-object"><a href="https://tc39.es/ecma262/#function-object">function object</a></emu-xref> that unconditionally throws a new instance of <emu-xref href="#sec-native-error-types-used-in-this-standard-typeerror"><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">%TypeError%</a></emu-xref>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-%typedarray%-intrinsic-object"><a href="https://tc39.es/ecma262/#sec-%typedarray%-intrinsic-object">%TypedArray%</a></emu-xref>
+              </td>
+              <td>
+              </td>
+              <td>
+                The super class of all typed Array <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructors</a></emu-xref> (<emu-xref href="#sec-%typedarray%-intrinsic-object"><a href="https://tc39.es/ecma262/#sec-%typedarray%-intrinsic-object">23.2.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-native-error-types-used-in-this-standard-typeerror"><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">%TypeError%</a></emu-xref>
+              </td>
+              <td>
+                <code>TypeError</code>
+              </td>
+              <td>
+                The TypeError <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-native-error-types-used-in-this-standard-typeerror"><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">20.5.5.5</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">%Uint8Array%</a></emu-xref>
+              </td>
+              <td>
+                <code>Uint8Array</code>
+              </td>
+              <td>
+                The Uint8Array <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">23.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">%Uint8ClampedArray%</a></emu-xref>
+              </td>
+              <td>
+                <code>Uint8ClampedArray</code>
+              </td>
+              <td>
+                The Uint8ClampedArray <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">23.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">%Uint16Array%</a></emu-xref>
+              </td>
+              <td>
+                <code>Uint16Array</code>
+              </td>
+              <td>
+                The Uint16Array <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">23.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">%Uint32Array%</a></emu-xref>
+              </td>
+              <td>
+                <code>Uint32Array</code>
+              </td>
+              <td>
+                The Uint32Array <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-typedarray-objects"><a href="https://tc39.es/ecma262/#sec-typedarray-objects">23.2</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-native-error-types-used-in-this-standard-urierror"><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-urierror">%URIError%</a></emu-xref>
+              </td>
+              <td>
+                <code>URIError</code>
+              </td>
+              <td>
+                The URIError <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-native-error-types-used-in-this-standard-urierror"><a href="https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-urierror">20.5.5.6</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-weakmap-constructor"><a href="https://tc39.es/ecma262/#sec-weakmap-constructor">%WeakMap%</a></emu-xref>
+              </td>
+              <td>
+                <code>WeakMap</code>
+              </td>
+              <td>
+                The WeakMap <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-weakmap-constructor"><a href="https://tc39.es/ecma262/#sec-weakmap-constructor">24.3.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-weak-ref-constructor"><a href="https://tc39.es/ecma262/#sec-weak-ref-constructor">%WeakRef%</a></emu-xref>
+              </td>
+              <td>
+                <code>WeakRef</code>
+              </td>
+              <td>
+                The <emu-xref href="#sec-weak-ref-constructor"><a href="https://tc39.es/ecma262/#sec-weak-ref-constructor">WeakRef</a></emu-xref> <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-weak-ref-constructor"><a href="https://tc39.es/ecma262/#sec-weak-ref-constructor">26.1.1</a></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <emu-xref href="#sec-weakset-constructor"><a href="https://tc39.es/ecma262/#sec-weakset-constructor">%WeakSet%</a></emu-xref>
+              </td>
+              <td>
+                <code>WeakSet</code>
+              </td>
+              <td>
+                The WeakSet <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> (<emu-xref href="#sec-weakset-constructor"><a href="https://tc39.es/ecma262/#sec-weakset-constructor">24.4.1</a></emu-xref>)
+              </td>
+            </tr>
+          </tbody></table>
+        </figure></emu-table>
+        <emu-note><span class="note">Note</span><div class="note-contents">
+          <p>Additional entries in <emu-xref href="#table-additional-well-known-intrinsic-objects"><a href="https://tc39.es/ecma262/#table-additional-well-known-intrinsic-objects">Table 91</a></emu-xref>.</p>
+        </div></emu-note>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+</emu-clause>
 
 <emu-clause id="sec-ecmascript-language-expressions" number="13">
   <h1><span class="secnum">13</span> ECMAScript Language: Expressions</h1>
@@ -2558,15 +3344,15 @@ li.menu-search-result-term:before {
         <h1><span class="secnum">13.3.10.1</span> Runtime Semantics: Evaluation</h1>
 
         <emu-grammar><emu-production name="ImportCall" collapsed="">
-    <emu-nt><a href="#prod-ImportCall">ImportCall</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="jskt5mpw" id="prod-4N8EtSSM">
+    <emu-nt><a href="#prod-ImportCall">ImportCall</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="s_udh2yu" id="prod-4N8EtSSM">
         <emu-t>import</emu-t>
         <emu-t>(</emu-t>
-        <emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt>
+        <emu-nt params="+In, ?Yield, ?Await"><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a><emu-mods><emu-params>[+In, ?Yield, ?Await]</emu-params></emu-mods></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-        <emu-alg><ol><li><ins>Return ?&nbsp;<emu-xref aoid="EvaluateImportCall" id="_ref_10"><a href="#sec-evaluate-import-call">EvaluateImportCall</a></emu-xref>(<emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt>, <emu-const>evaluation</emu-const>).</ins></li><li><del>Let <var>referrer</var> be <emu-xref aoid="GetActiveScriptOrModule"><a href="https://tc39.es/ecma262/#sec-getactivescriptormodule">GetActiveScriptOrModule</a></emu-xref>().</del></li><li><del>If <var>referrer</var> is <emu-val>null</emu-val>, set <var>referrer</var> to <emu-xref href="#current-realm"><a href="https://tc39.es/ecma262/#current-realm">the current Realm Record</a></emu-xref>.</del></li><li><del>Let <var>argRef</var> be ?&nbsp;<emu-xref aoid="Evaluation"><a href="https://tc39.es/ecma262/#sec-evaluation">Evaluation</a></emu-xref> of <emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt>.</del></li><li><del>Let <var>specifier</var> be ?&nbsp;<emu-xref aoid="GetValue"><a href="https://tc39.es/ecma262/#sec-getvalue">GetValue</a></emu-xref>(<var>argRef</var>).</del></li><li><del>Let <var>promiseCapability</var> be !&nbsp;<emu-xref aoid="NewPromiseCapability"><a href="https://tc39.es/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(<emu-xref href="#sec-promise-constructor"><a href="https://tc39.es/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>).</del></li><li><del>Let <var>specifierString</var> be <emu-xref aoid="Completion"><a href="https://tc39.es/ecma262/#sec-completion-ao">Completion</a></emu-xref>(<emu-xref aoid="ToString"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>specifier</var>)).</del></li><li><del><emu-xref aoid="IfAbruptRejectPromise"><a href="https://tc39.es/ecma262/#sec-ifabruptrejectpromise">IfAbruptRejectPromise</a></emu-xref>(<var>specifierString</var>, <var>promiseCapability</var>).</del></li><li><del>Perform <emu-xref aoid="HostLoadImportedModule" id="_ref_11"><a href="#sec-HostLoadImportedModule">HostLoadImportedModule</a></emu-xref>(<var>referrer</var>, <var>specifierString</var>, <emu-const>empty</emu-const>, <var>promiseCapability</var>).</del></li><li><del>Return <var>promiseCapability</var>.[[Promise]].</del></li></ol></emu-alg>
+        <emu-alg><ol><li><del>Let <var>referrer</var> be <emu-xref aoid="GetActiveScriptOrModule"><a href="https://tc39.es/ecma262/#sec-getactivescriptormodule">GetActiveScriptOrModule</a></emu-xref>().</del></li><li><del>If <var>referrer</var> is <emu-val>null</emu-val>, set <var>referrer</var> to <emu-xref href="#current-realm"><a href="https://tc39.es/ecma262/#current-realm">the current Realm Record</a></emu-xref>.</del></li><li><del>Let <var>argRef</var> be ?&nbsp;<emu-xref aoid="Evaluation"><a href="https://tc39.es/ecma262/#sec-evaluation">Evaluation</a></emu-xref> of <emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt>.</del></li><li><del>Let <var>specifier</var> be ?&nbsp;<emu-xref aoid="GetValue"><a href="https://tc39.es/ecma262/#sec-getvalue">GetValue</a></emu-xref>(<var>argRef</var>).</del></li><li><del>Let <var>promiseCapability</var> be !&nbsp;<emu-xref aoid="NewPromiseCapability"><a href="https://tc39.es/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(<emu-xref href="#sec-promise-constructor"><a href="https://tc39.es/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>).</del></li><li><del>Let <var>specifierString</var> be <emu-xref aoid="Completion"><a href="https://tc39.es/ecma262/#sec-completion-ao">Completion</a></emu-xref>(<emu-xref aoid="ToString"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>specifier</var>)).</del></li><li><del><emu-xref aoid="IfAbruptRejectPromise"><a href="https://tc39.es/ecma262/#sec-ifabruptrejectpromise">IfAbruptRejectPromise</a></emu-xref>(<var>specifierString</var>, <var>promiseCapability</var>).</del></li><li><del>Perform <emu-xref aoid="HostLoadImportedModule" id="_ref_12"><a href="#sec-HostLoadImportedModule">HostLoadImportedModule</a></emu-xref>(<var>referrer</var>, <var>specifierString</var>, <emu-const>empty</emu-const>, <var>promiseCapability</var>).</del></li><li><del>Return <var>promiseCapability</var>.[[Promise]].</del></li><li><ins>Return ?&nbsp;<emu-xref aoid="EvaluateImportCall" id="_ref_13"><a href="#sec-evaluate-import-call">EvaluateImportCall</a></emu-xref>(<emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt>, <emu-const>evaluation</emu-const>).</ins></li></ol></emu-alg>
 
         <emu-grammar><ins><emu-production name="ImportCall" collapsed="">
     <emu-nt><a href="#prod-ImportCall">ImportCall</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="squwtgf4" id="prod-E9lFAjcF">
@@ -2579,18 +3365,18 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production></ins>
 </emu-grammar>
-        <emu-alg><ol><li><ins>Return ?&nbsp;<emu-xref aoid="EvaluateImportCall" id="_ref_12"><a href="#sec-evaluate-import-call">EvaluateImportCall</a></emu-xref>(<emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt>, <emu-const>source</emu-const>).</ins></li></ol></emu-alg>
+        <emu-alg><ol><li><ins>Return ?&nbsp;<emu-xref aoid="EvaluateImportCall" id="_ref_14"><a href="#sec-evaluate-import-call">EvaluateImportCall</a></emu-xref>(<emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt>, <emu-const>source</emu-const>).</ins></li></ol></emu-alg>
       </emu-clause>
 
       <emu-clause id="sec-evaluate-import-call" type="abstract operation" aoid="EvaluateImportCall">
         <h1><span class="secnum">13.3.10.2</span> <ins>EvaluateImportCall ( <var>specifierExpression</var>, <var>phase</var> )</ins></h1>
         <p>The abstract operation EvaluateImportCall takes arguments <var>specifierExpression</var> (a <emu-xref href="#sec-syntactic-grammar"><a href="https://tc39.es/ecma262/#sec-syntactic-grammar">Parse Node</a></emu-xref>) and <var>phase</var> (<emu-const>source</emu-const> or <emu-const>evaluation</emu-const>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a Promise or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. It performs the following steps when called:</p>
-        <emu-alg><ol><li>Let <var>referrer</var> be <emu-xref aoid="GetActiveScriptOrModule"><a href="https://tc39.es/ecma262/#sec-getactivescriptormodule">GetActiveScriptOrModule</a></emu-xref>().</li><li>If <var>referrer</var> is <emu-val>null</emu-val>, set <var>referrer</var> to <emu-xref href="#current-realm"><a href="https://tc39.es/ecma262/#current-realm">the current Realm Record</a></emu-xref>.</li><li>Let <var>specifierRef</var> be ?&nbsp;<emu-xref aoid="Evaluation"><a href="https://tc39.es/ecma262/#sec-evaluation">Evaluation</a></emu-xref> of evaluating <var>specifierExpression</var>.</li><li>Let <var>specifier</var> be ?&nbsp;<emu-xref aoid="GetValue"><a href="https://tc39.es/ecma262/#sec-getvalue">GetValue</a></emu-xref>(<var>specifierRef</var>).</li><li>Let <var>promiseCapability</var> be !&nbsp;<emu-xref aoid="NewPromiseCapability"><a href="https://tc39.es/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(<emu-xref href="#sec-promise-constructor"><a href="https://tc39.es/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>).</li><li>Let <var>specifierString</var> be <emu-xref aoid="Completion"><a href="https://tc39.es/ecma262/#sec-completion-ao">Completion</a></emu-xref>(<emu-xref aoid="ToString"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>specifier</var>)).</li><li><emu-xref aoid="IfAbruptRejectPromise"><a href="https://tc39.es/ecma262/#sec-ifabruptrejectpromise">IfAbruptRejectPromise</a></emu-xref>(<var>specifierString</var>, <var>promiseCapability</var>).</li><li>Let <var>moduleRequest</var> be a new <emu-xref href="#modulerequest-record" id="_ref_13"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> { [[Specifier]]: <var>specifierString</var>, [[Phase]]: <var>phase</var> }.</li><li>Perform <emu-xref aoid="HostLoadImportedModule" id="_ref_14"><a href="#sec-HostLoadImportedModule">HostLoadImportedModule</a></emu-xref>(<var>referrer</var>, <var>moduleRequest</var>, <emu-const>empty</emu-const>, <var>promiseCapability</var>).</li><li>Return <var>promiseCapability</var>.[[Promise]].</li></ol></emu-alg>
+        <emu-alg><ol><li>Let <var>referrer</var> be <emu-xref aoid="GetActiveScriptOrModule"><a href="https://tc39.es/ecma262/#sec-getactivescriptormodule">GetActiveScriptOrModule</a></emu-xref>().</li><li>If <var>referrer</var> is <emu-val>null</emu-val>, set <var>referrer</var> to <emu-xref href="#current-realm"><a href="https://tc39.es/ecma262/#current-realm">the current Realm Record</a></emu-xref>.</li><li>Let <var>specifierRef</var> be ?&nbsp;<emu-xref aoid="Evaluation"><a href="https://tc39.es/ecma262/#sec-evaluation">Evaluation</a></emu-xref> of evaluating <var>specifierExpression</var>.</li><li>Let <var>specifier</var> be ?&nbsp;<emu-xref aoid="GetValue"><a href="https://tc39.es/ecma262/#sec-getvalue">GetValue</a></emu-xref>(<var>specifierRef</var>).</li><li>Let <var>promiseCapability</var> be !&nbsp;<emu-xref aoid="NewPromiseCapability"><a href="https://tc39.es/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(<emu-xref href="#sec-promise-constructor"><a href="https://tc39.es/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>).</li><li>Let <var>specifierString</var> be <emu-xref aoid="Completion"><a href="https://tc39.es/ecma262/#sec-completion-ao">Completion</a></emu-xref>(<emu-xref aoid="ToString"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>specifier</var>)).</li><li><emu-xref aoid="IfAbruptRejectPromise"><a href="https://tc39.es/ecma262/#sec-ifabruptrejectpromise">IfAbruptRejectPromise</a></emu-xref>(<var>specifierString</var>, <var>promiseCapability</var>).</li><li>Let <var>moduleRequest</var> be a new <emu-xref href="#modulerequest-record" id="_ref_15"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> { [[Specifier]]: <var>specifierString</var>, [[Phase]]: <var>phase</var> }.</li><li>Perform <emu-xref aoid="HostLoadImportedModule" id="_ref_16"><a href="#sec-HostLoadImportedModule">HostLoadImportedModule</a></emu-xref>(<var>referrer</var>, <var>moduleRequest</var>, <emu-const>empty</emu-const>, <var>promiseCapability</var>).</li><li>Return <var>promiseCapability</var>.[[Promise]].</li></ol></emu-alg>
 
         <emu-clause id="sec-ContinueDynamicImport" type="abstract operation" aoid="ContinueDynamicImport">
           <h1><span class="secnum">13.3.10.2.1</span> ContinueDynamicImport ( <var>promiseCapability</var>, <ins><var>phase</var></ins>, <var>moduleCompletion</var> )</h1>
-          <p>The abstract operation ContinueDynamicImport takes arguments <var>promiseCapability</var> (a <emu-xref href="#sec-promisecapability-records"><a href="https://tc39.es/ecma262/#sec-promisecapability-records">PromiseCapability Record</a></emu-xref>), <ins><var>phase</var> (<emu-const>source</emu-const> or <emu-const>evaluation</emu-const>)</ins>, and <var>moduleCompletion</var> (either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a <emu-xref href="#sec-abstract-module-records" id="_ref_15"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>) and returns <emu-const>unused</emu-const>. It completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls" id="_ref_0"><a href="#sec-import-calls"><code>import()</code></a></emu-xref> call, resolving or rejecting the promise returned by that call as appropriate. It performs the following steps when called:</p>
-          <emu-alg><ol><li>If <var>moduleCompletion</var> is an <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref>, then<ol><li>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Reject]], <emu-val>undefined</emu-val>, « <var>moduleCompletion</var>.[[Value]] »).</li><li>Return <emu-const>unused</emu-const>.</li></ol></li><li>Let <var>module</var> be <var>moduleCompletion</var>.[[Value]].</li><li><ins>If <var>phase</var> is <emu-const>source</emu-const>, then</ins><ol><li><ins>Let <var>moduleSourceObject</var> be <emu-xref aoid="Completion"><a href="https://tc39.es/ecma262/#sec-completion-ao">Completion</a></emu-xref>(<var>module</var>.GetModuleSource()).</ins></li><li><ins>If <var>moduleSourceObject</var> is an <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref>, then</ins><ol><li><ins>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Reject]], <emu-val>undefined</emu-val>, « <var>moduleSourceObject</var>.[[Value]] »).</ins></li></ol></li><li><ins>Else,</ins><ol><li><ins>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Resolve]], <emu-val>undefined</emu-val>, « <var>moduleSourceObject</var>.[[Value]] »).</ins></li></ol></li><li><ins>Return <emu-const>unused</emu-const>.</ins></li></ol></li><li>Let <var>loadPromise</var> be <var>module</var>.LoadRequestedModules().</li><li>Let <var>rejectedClosure</var> be a new <emu-xref href="#sec-abstract-closure"><a href="https://tc39.es/ecma262/#sec-abstract-closure">Abstract Closure</a></emu-xref> with parameters (<var>reason</var>) that captures <var>promiseCapability</var> and performs the following steps when called:<ol><li>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Reject]], <emu-val>undefined</emu-val>, « <var>reason</var> »).</li><li>Return <emu-const>unused</emu-const>.</li></ol></li><li>Let <var>onRejected</var> be <emu-xref aoid="CreateBuiltinFunction"><a href="https://tc39.es/ecma262/#sec-createbuiltinfunction">CreateBuiltinFunction</a></emu-xref>(<var>rejectedClosure</var>, 1, <emu-val>""</emu-val>, « »).</li><li>Let <var>linkAndEvaluateClosure</var> be a new <emu-xref href="#sec-abstract-closure"><a href="https://tc39.es/ecma262/#sec-abstract-closure">Abstract Closure</a></emu-xref> with no parameters that captures <var>module</var>, <var>promiseCapability</var>, and <var>onRejected</var> and performs the following steps when called:<ol><li>Let <var>link</var> be <emu-xref aoid="Completion"><a href="https://tc39.es/ecma262/#sec-completion-ao">Completion</a></emu-xref>(<var>module</var>.Link()).</li><li>If <var>link</var> is an <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref>, then<ol><li>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Reject]], <emu-val>undefined</emu-val>, « <var>link</var>.[[Value]] »).</li><li>Return <emu-const>unused</emu-const>.</li></ol></li><li>Let <var>evaluatePromise</var> be <var>module</var>.Evaluate().</li><li>Let <var>fulfilledClosure</var> be a new <emu-xref href="#sec-abstract-closure"><a href="https://tc39.es/ecma262/#sec-abstract-closure">Abstract Closure</a></emu-xref> with no parameters that captures <var>module</var> and <var>promiseCapability</var> and performs the following steps when called:<ol><li>Let <var>namespace</var> be <emu-xref aoid="GetModuleNamespace"><a href="https://tc39.es/ecma262/#sec-getmodulenamespace">GetModuleNamespace</a></emu-xref>(<var>module</var>).</li><li>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Resolve]], <emu-val>undefined</emu-val>, « <var>namespace</var> »).</li><li>Return <emu-const>unused</emu-const>.</li></ol></li><li>Let <var>onFulfilled</var> be <emu-xref aoid="CreateBuiltinFunction"><a href="https://tc39.es/ecma262/#sec-createbuiltinfunction">CreateBuiltinFunction</a></emu-xref>(<var>fulfilledClosure</var>, <emu-val>""</emu-val>, 0, « »).</li><li>Perform <emu-xref aoid="PerformPromiseThen"><a href="https://tc39.es/ecma262/#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>evaluatePromise</var>, <var>onFulfilled</var>, <var>onRejected</var>).</li></ol></li><li>Let <var>linkAndEvaluate</var> be <emu-xref aoid="CreateBuiltinFunction"><a href="https://tc39.es/ecma262/#sec-createbuiltinfunction">CreateBuiltinFunction</a></emu-xref>(<var>linkAndEvaluateClosure</var>, <emu-val>""</emu-val>, 0, « »).</li><li>Perform <emu-xref aoid="PerformPromiseThen"><a href="https://tc39.es/ecma262/#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>loadPromise</var>, <var>linkAndEvaluate</var>, <var>onRejected</var>).</li><li>Return <emu-const>unused</emu-const>.</li></ol></emu-alg>
+          <p>The abstract operation ContinueDynamicImport takes arguments <var>promiseCapability</var> (a <emu-xref href="#sec-promisecapability-records"><a href="https://tc39.es/ecma262/#sec-promisecapability-records">PromiseCapability Record</a></emu-xref>), <ins><var>phase</var> (<emu-const>source</emu-const> or <emu-const>evaluation</emu-const>)</ins>, and <var>moduleCompletion</var> (either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a <emu-xref href="#sec-abstract-module-records" id="_ref_17"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>) and returns <emu-const>unused</emu-const>. It completes the process of a dynamic import originally started by an <emu-xref href="#sec-import-calls" id="_ref_2"><a href="#sec-import-calls"><code>import()</code></a></emu-xref> call, resolving or rejecting the promise returned by that call as appropriate. It performs the following steps when called:</p>
+          <emu-alg><ol><li>If <var>moduleCompletion</var> is an <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref>, then<ol><li>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Reject]], <emu-val>undefined</emu-val>, « <var>moduleCompletion</var>.[[Value]] »).</li><li>Return <emu-const>unused</emu-const>.</li></ol></li><li>Let <var>module</var> be <var>moduleCompletion</var>.[[Value]].</li><li><ins>If <var>phase</var> is <emu-const>source</emu-const>, then</ins><ol><li><ins>Let <var>moduleSourceCompletion</var> be <emu-xref aoid="Completion"><a href="https://tc39.es/ecma262/#sec-completion-ao">Completion</a></emu-xref>(<var>module</var>.GetModuleSource()).</ins></li><li><ins>If <var>moduleSourceCompletion</var> is an <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref>, then</ins><ol><li><ins>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Reject]], <emu-val>undefined</emu-val>, « <var>moduleSourceCompletion</var>.[[Value]] »).</ins></li></ol></li><li><ins>Else,</ins><ol><li><ins>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Resolve]], <emu-val>undefined</emu-val>, « <var>moduleSourceCompletion</var>.[[Value]] »).</ins></li></ol></li><li><ins>Return <emu-const>unused</emu-const>.</ins></li></ol></li><li>Let <var>loadPromise</var> be <var>module</var>.LoadRequestedModules().</li><li>Let <var>rejectedClosure</var> be a new <emu-xref href="#sec-abstract-closure"><a href="https://tc39.es/ecma262/#sec-abstract-closure">Abstract Closure</a></emu-xref> with parameters (<var>reason</var>) that captures <var>promiseCapability</var> and performs the following steps when called:<ol><li>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Reject]], <emu-val>undefined</emu-val>, « <var>reason</var> »).</li><li>Return <emu-const>unused</emu-const>.</li></ol></li><li>Let <var>onRejected</var> be <emu-xref aoid="CreateBuiltinFunction"><a href="https://tc39.es/ecma262/#sec-createbuiltinfunction">CreateBuiltinFunction</a></emu-xref>(<var>rejectedClosure</var>, 1, <emu-val>""</emu-val>, « »).</li><li>Let <var>linkAndEvaluateClosure</var> be a new <emu-xref href="#sec-abstract-closure"><a href="https://tc39.es/ecma262/#sec-abstract-closure">Abstract Closure</a></emu-xref> with no parameters that captures <var>module</var>, <var>promiseCapability</var>, and <var>onRejected</var> and performs the following steps when called:<ol><li>Let <var>link</var> be <emu-xref aoid="Completion"><a href="https://tc39.es/ecma262/#sec-completion-ao">Completion</a></emu-xref>(<var>module</var>.Link()).</li><li>If <var>link</var> is an <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref>, then<ol><li>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Reject]], <emu-val>undefined</emu-val>, « <var>link</var>.[[Value]] »).</li><li>Return <emu-const>unused</emu-const>.</li></ol></li><li>Let <var>evaluatePromise</var> be <var>module</var>.Evaluate().</li><li>Let <var>fulfilledClosure</var> be a new <emu-xref href="#sec-abstract-closure"><a href="https://tc39.es/ecma262/#sec-abstract-closure">Abstract Closure</a></emu-xref> with no parameters that captures <var>module</var> and <var>promiseCapability</var> and performs the following steps when called:<ol><li>Let <var>namespace</var> be <emu-xref aoid="GetModuleNamespace"><a href="https://tc39.es/ecma262/#sec-getmodulenamespace">GetModuleNamespace</a></emu-xref>(<var>module</var>).</li><li>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>promiseCapability</var>.[[Resolve]], <emu-val>undefined</emu-val>, « <var>namespace</var> »).</li><li>Return <emu-const>unused</emu-const>.</li></ol></li><li>Let <var>onFulfilled</var> be <emu-xref aoid="CreateBuiltinFunction"><a href="https://tc39.es/ecma262/#sec-createbuiltinfunction">CreateBuiltinFunction</a></emu-xref>(<var>fulfilledClosure</var>, <emu-val>""</emu-val>, 0, « »).</li><li>Perform <emu-xref aoid="PerformPromiseThen"><a href="https://tc39.es/ecma262/#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>evaluatePromise</var>, <var>onFulfilled</var>, <var>onRejected</var>).</li></ol></li><li>Let <var>linkAndEvaluate</var> be <emu-xref aoid="CreateBuiltinFunction"><a href="https://tc39.es/ecma262/#sec-createbuiltinfunction">CreateBuiltinFunction</a></emu-xref>(<var>linkAndEvaluateClosure</var>, <emu-val>""</emu-val>, 0, « »).</li><li>Perform <emu-xref aoid="PerformPromiseThen"><a href="https://tc39.es/ecma262/#sec-performpromisethen">PerformPromiseThen</a></emu-xref>(<var>loadPromise</var>, <var>linkAndEvaluate</var>, <var>onRejected</var>).</li><li>Return <emu-const>unused</emu-const>.</li></ol></emu-alg>
         </emu-clause>
       </emu-clause>
     </emu-clause>
@@ -2610,7 +3396,7 @@ li.menu-search-result-term:before {
         <h1><span class="secnum">16.1.1.1</span> <ins>ModuleRequest Records</ins></h1>
 
         <p>A <dfn id="modulerequest-record" variants="ModuleRequest Records">ModuleRequest Record</dfn> represents a request to import a module up to a given phase. It consists of the following fields:</p>
-        <emu-table id="table-modulerequest-record-fields" caption="ModuleRequest Record fields"><figure><figcaption>Table 1: <emu-xref href="#modulerequest-record" id="_ref_16"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> fields</figcaption>
+        <emu-table id="table-modulerequest-record-fields" caption="ModuleRequest Record fields"><figure><figcaption>Table 2: <emu-xref href="#modulerequest-record" id="_ref_18"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> fields</figcaption>
           <table>
             <tbody>
               <tr>
@@ -2629,7 +3415,7 @@ li.menu-search-result-term:before {
                   [[Specifier]]
                 </td>
                 <td>
-                  String
+                  a String
                 </td>
                 <td>
                   The module specifier
@@ -2650,12 +3436,12 @@ li.menu-search-result-term:before {
           </table>
         </figure></emu-table>
 
-        <emu-note type="editor"><span class="note">Editor's Note</span><div class="note-contents">In general, this proposal replaces places where module specifiers are passed around with <emu-xref href="#modulerequest-record" id="_ref_17"><a href="#modulerequest-record">ModuleRequest Records</a></emu-xref>. For example, several <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operations</a></emu-xref>, such as <emu-xref aoid="ModuleRequests" id="_ref_18"><a href="#sec-static-semantics-modulerequests">ModuleRequests</a></emu-xref> produce <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Lists</a></emu-xref> of <emu-xref href="#modulerequest-record" id="_ref_19"><a href="#modulerequest-record">ModuleRequest Records</a></emu-xref> rather than <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Lists</a></emu-xref> of Strings which are interpreted as module specifiers. Some algorithms like <emu-xref aoid="ImportEntries" id="_ref_20"><a href="#sec-static-semantics-importentries">ImportEntries</a></emu-xref> and <emu-xref aoid="ImportEntriesForModule"><a href="https://tc39.es/ecma262/#sec-static-semantics-importentriesformodule">ImportEntriesForModule</a></emu-xref> pass around <emu-xref href="#modulerequest-record" id="_ref_21"><a href="#modulerequest-record">ModuleRequest Records</a></emu-xref> rather than Strings, in a way which doesn't require any particular textual change. Additionally, record fields in <emu-xref href="#cyclic-module-record" id="_ref_22"><a href="#cyclic-module-record">Cyclic Module Records</a></emu-xref> and <emu-xref href="#sourctextmodule-record"><a href="https://tc39.es/ecma262/#sourctextmodule-record">Source Text Module Records</a></emu-xref> which contained <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Lists</a></emu-xref> of Strings are replaced by <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Lists</a></emu-xref> of <emu-xref href="#modulerequest-record" id="_ref_23"><a href="#modulerequest-record">ModuleRequest Records</a></emu-xref>, as indicated above.</div></emu-note>
+        <emu-note type="editor"><span class="note">Editor's Note</span><div class="note-contents">In general, this proposal replaces places where module specifiers are passed around with <emu-xref href="#modulerequest-record" id="_ref_19"><a href="#modulerequest-record">ModuleRequest Records</a></emu-xref>. For example, several <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operations</a></emu-xref>, such as <emu-xref aoid="ModuleRequests" id="_ref_20"><a href="#sec-static-semantics-modulerequests">ModuleRequests</a></emu-xref> produce <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Lists</a></emu-xref> of <emu-xref href="#modulerequest-record" id="_ref_21"><a href="#modulerequest-record">ModuleRequest Records</a></emu-xref> rather than <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Lists</a></emu-xref> of Strings which are interpreted as module specifiers. Some algorithms like <emu-xref aoid="ImportEntries" id="_ref_22"><a href="#sec-static-semantics-importentries">ImportEntries</a></emu-xref> and <emu-xref aoid="ImportEntriesForModule"><a href="https://tc39.es/ecma262/#sec-static-semantics-importentriesformodule">ImportEntriesForModule</a></emu-xref> pass around <emu-xref href="#modulerequest-record" id="_ref_23"><a href="#modulerequest-record">ModuleRequest Records</a></emu-xref> rather than Strings, in a way which doesn't require any particular textual change. Additionally, record fields in <emu-xref href="#cyclic-module-record" id="_ref_24"><a href="#cyclic-module-record">Cyclic Module Records</a></emu-xref> and <emu-xref href="#sourctextmodule-record"><a href="https://tc39.es/ecma262/#sourctextmodule-record">Source Text Module Records</a></emu-xref> which contained <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Lists</a></emu-xref> of Strings are replaced by <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Lists</a></emu-xref> of <emu-xref href="#modulerequest-record" id="_ref_25"><a href="#modulerequest-record">ModuleRequest Records</a></emu-xref>, as indicated above.</div></emu-note>
       </emu-clause>
 
       <emu-clause id="sec-static-semantics-modulerequests" type="sdo" number="3" aoid="ModuleRequests">
         <h1><span class="secnum">16.1.1.3</span> Static Semantics: ModuleRequests</h1>
-        <p>The <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operation</a></emu-xref> ModuleRequests takes no arguments and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <del>Strings</del><ins><emu-xref href="#modulerequest-record" id="_ref_24"><a href="#modulerequest-record">ModuleRequest Records</a></emu-xref></ins>. It is defined piecewise over the following productions:</p>
+        <p>The <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operation</a></emu-xref> ModuleRequests takes no arguments and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <del>Strings</del><ins><emu-xref href="#modulerequest-record" id="_ref_26"><a href="#modulerequest-record">ModuleRequest Records</a></emu-xref></ins>. It is defined piecewise over the following productions:</p>
         <emu-grammar><emu-production name="Module" collapsed="">
     <emu-nt><a href="https://tc39.es/ecma262/#prod-Module">Module</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="n7nathbb"><emu-gann>[empty]</emu-gann></emu-rhs>
 </emu-production>
@@ -2665,7 +3451,7 @@ li.menu-search-result-term:before {
     <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItemList">ModuleItemList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ap7dhqxm"><emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItem">ModuleItem</a></emu-nt></emu-rhs>
 </emu-production>
 </emu-grammar>
-        <emu-alg><ol><li>Return <emu-xref aoid="ModuleRequests" id="_ref_25"><a href="#sec-static-semantics-modulerequests">ModuleRequests</a></emu-xref> of <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItem">ModuleItem</a></emu-nt>.</li></ol></emu-alg>
+        <emu-alg><ol><li>Return <emu-xref aoid="ModuleRequests" id="_ref_27"><a href="#sec-static-semantics-modulerequests">ModuleRequests</a></emu-xref> of <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItem">ModuleItem</a></emu-nt>.</li></ol></emu-alg>
         <emu-grammar><emu-production name="ModuleItemList" collapsed="">
     <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItemList">ModuleItemList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="dd23jrxs">
         <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItemList">ModuleItemList</a></emu-nt>
@@ -2673,7 +3459,7 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-        <emu-alg><ol><li>Let <del><var>moduleNames</var></del><ins><var>requests</var></ins> be <emu-xref aoid="ModuleRequests" id="_ref_26"><a href="#sec-static-semantics-modulerequests">ModuleRequests</a></emu-xref> of <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItemList">ModuleItemList</a></emu-nt>.</li><li>Let <del><var>additionalNames</var></del><ins><var>additionalRequests</var></ins> be <emu-xref aoid="ModuleRequests" id="_ref_27"><a href="#sec-static-semantics-modulerequests">ModuleRequests</a></emu-xref> of <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItem">ModuleItem</a></emu-nt>.</li><li><del>For each String <var>name</var> of <var>additionalNames</var>, do</del></li><li><ins>For each <emu-xref href="#modulerequest-record" id="_ref_28"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> <var>mr</var> of <var>additionalRequests</var>, do</ins><ol><li><ins>Let <var>found</var> be <emu-val>false</emu-val>.</ins></li><li><ins>For each <emu-xref href="#modulerequest-record" id="_ref_29"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> <var>mr2</var> of <var>requests</var>, do</ins><ol><li><ins>If <var>mr</var>.[[Specifer]] is <var>mr2</var>.[[Specifer]] and <var>mr</var>.[[Phase]] is <var>mr2</var>.[[Phase]], then</ins><ol><li><ins><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>found</var> is <emu-val>false</emu-val>.</ins></li><li><ins>Set <var>found</var> to <emu-val>true</emu-val>.</ins></li></ol></li></ol></li><li><del>If <var>moduleNames</var> does not contain <var>name</var>, then</del></li><li><ins>If <var>found</var> is <emu-val>false</emu-val>, then</ins><ol><li>Append <del><var>name</var></del><ins><var>mr</var></ins> to <del><var>moduleNames</var></del><ins><var>requests</var></ins>.</li></ol></li></ol></li><li>Return <del><var>moduleNames</var></del><ins><var>requests</var></ins>.</li></ol></emu-alg>
+        <emu-alg><ol><li>Let <del><var>moduleNames</var></del><ins><var>requests</var></ins> be <emu-xref aoid="ModuleRequests" id="_ref_28"><a href="#sec-static-semantics-modulerequests">ModuleRequests</a></emu-xref> of <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItemList">ModuleItemList</a></emu-nt>.</li><li>Let <del><var>additionalNames</var></del><ins><var>additionalRequests</var></ins> be <emu-xref aoid="ModuleRequests" id="_ref_29"><a href="#sec-static-semantics-modulerequests">ModuleRequests</a></emu-xref> of <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItem">ModuleItem</a></emu-nt>.</li><li><del>For each String <var>name</var> of <var>additionalNames</var>, do</del></li><li><ins>For each <emu-xref href="#modulerequest-record" id="_ref_30"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> <var>mr</var> of <var>additionalRequests</var>, do</ins><ol><li><ins>Let <var>found</var> be <emu-val>false</emu-val>.</ins></li><li><ins>For each <emu-xref href="#modulerequest-record" id="_ref_31"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> <var>mr2</var> of <var>requests</var>, do</ins><ol><li><ins>If <var>mr</var>.[[Specifer]] is <var>mr2</var>.[[Specifer]] and <var>mr</var>.[[Phase]] is <var>mr2</var>.[[Phase]], then</ins><ol><li><ins><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>found</var> is <emu-val>false</emu-val>.</ins></li><li><ins>Set <var>found</var> to <emu-val>true</emu-val>.</ins></li></ol></li></ol></li><li><del>If <var>moduleNames</var> does not contain <var>name</var>, then</del></li><li><ins>If <var>found</var> is <emu-val>false</emu-val>, then</ins><ol><li>Append <del><var>name</var></del><ins><var>mr</var></ins> to <del><var>moduleNames</var></del><ins><var>requests</var></ins>.</li></ol></li></ol></li><li>Return <del><var>moduleNames</var></del><ins><var>requests</var></ins>.</li></ol></emu-alg>
         <emu-grammar><emu-production name="ModuleItem" collapsed="">
     <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItem">ModuleItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="15hryu6r"><emu-nt><a href="https://tc39.es/ecma262/#prod-StatementListItem">StatementListItem</a></emu-nt></emu-rhs>
 </emu-production>
@@ -2682,24 +3468,24 @@ li.menu-search-result-term:before {
         <emu-grammar><emu-production name="ImportDeclaration" collapsed="">
     <emu-nt><a href="#prod-ImportDeclaration">ImportDeclaration</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="glhuxxec" id="prod-Fii3Jv-w">
         <emu-t>import</emu-t>
-        <emu-nt id="_ref_122"><a href="#prod-ImportClause">ImportClause</a></emu-nt>
-        <emu-nt id="_ref_123"><a href="#prod-FromClause">FromClause</a></emu-nt>
+        <emu-nt id="_ref_119"><a href="#prod-ImportClause">ImportClause</a></emu-nt>
+        <emu-nt id="_ref_120"><a href="#prod-FromClause">FromClause</a></emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-        <emu-alg><ol><li><del>Return <emu-xref aoid="ModuleRequests" id="_ref_30"><a href="#sec-static-semantics-modulerequests">ModuleRequests</a></emu-xref> of <emu-nt id="_ref_124"><a href="#prod-FromClause">FromClause</a></emu-nt>.</del></li><li><ins>Let <var>specifier</var> be <emu-xref aoid="SV"><a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a></emu-xref> of <emu-nt id="_ref_125"><a href="#prod-FromClause">FromClause</a></emu-nt>.</ins></li><li><ins>Return a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose sole element is the <emu-xref href="#modulerequest-record" id="_ref_31"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> { [[Specifer]]: <var>specifier</var>, [[Phase]]: <emu-const>evaluation</emu-const> }.</ins></li></ol></emu-alg>
+        <emu-alg><ol><li><del>Return <emu-xref aoid="ModuleRequests" id="_ref_32"><a href="#sec-static-semantics-modulerequests">ModuleRequests</a></emu-xref> of <emu-nt id="_ref_121"><a href="#prod-FromClause">FromClause</a></emu-nt>.</del></li><li><ins>Let <var>specifier</var> be <emu-xref aoid="SV"><a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a></emu-xref> of <emu-nt id="_ref_122"><a href="#prod-FromClause">FromClause</a></emu-nt>.</ins></li><li><ins>Return a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose sole element is the <emu-xref href="#modulerequest-record" id="_ref_33"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> { [[Specifer]]: <var>specifier</var>, [[Phase]]: <emu-const>evaluation</emu-const> }.</ins></li></ol></emu-alg>
         <emu-grammar><ins><emu-production name="ImportDeclaration" collapsed="">
     <emu-nt><a href="#prod-ImportDeclaration">ImportDeclaration</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="dch9dh2n" id="prod-eGLun9tY">
         <emu-t>import</emu-t>
         <emu-t>source</emu-t>
-        <emu-nt id="_ref_126"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>
-        <emu-nt id="_ref_127"><a href="#prod-FromClause">FromClause</a></emu-nt>
+        <emu-nt id="_ref_123"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>
+        <emu-nt id="_ref_124"><a href="#prod-FromClause">FromClause</a></emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production></ins>
 </emu-grammar>
-        <emu-alg><ol><li><ins>Let <var>specifier</var> be <emu-xref aoid="SV"><a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a></emu-xref> of <emu-nt id="_ref_128"><a href="#prod-FromClause">FromClause</a></emu-nt>.</ins></li><li><ins>Return a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose sole element is the <emu-xref href="#modulerequest-record" id="_ref_32"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> { [[Specifer]]: <var>specifier</var>, [[Phase]]: <emu-const>source</emu-const> }.</ins></li></ol></emu-alg>
+        <emu-alg><ol><li><ins>Let <var>specifier</var> be <emu-xref aoid="SV"><a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a></emu-xref> of <emu-nt id="_ref_125"><a href="#prod-FromClause">FromClause</a></emu-nt>.</ins></li><li><ins>Return a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose sole element is the <emu-xref href="#modulerequest-record" id="_ref_34"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> { [[Specifer]]: <var>specifier</var>, [[Phase]]: <emu-const>source</emu-const> }.</ins></li></ol></emu-alg>
         <emu-grammar><del><emu-production name="ModuleSpecifier" collapsed="">
     <emu-nt><a href="#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="xhtltz00" id="prod-geKEXfWi"><emu-nt><a href="https://tc39.es/ecma262/#prod-StringLiteral">StringLiteral</a></emu-nt></emu-rhs>
 </emu-production></del>
@@ -2709,12 +3495,12 @@ li.menu-search-result-term:before {
     <emu-nt><a href="https://tc39.es/ecma262/#prod-ExportDeclaration">ExportDeclaration</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="4kqfdugp">
         <emu-t>export</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-ExportFromClause">ExportFromClause</a></emu-nt>
-        <emu-nt id="_ref_129"><a href="#prod-FromClause">FromClause</a></emu-nt>
+        <emu-nt id="_ref_126"><a href="#prod-FromClause">FromClause</a></emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-        <emu-alg><ol><li><del>Return <emu-xref aoid="ModuleRequests" id="_ref_33"><a href="#sec-static-semantics-modulerequests">ModuleRequests</a></emu-xref> of <emu-nt id="_ref_130"><a href="#prod-FromClause">FromClause</a></emu-nt>.</del></li><li><ins>Let <var>specifier</var> be <emu-xref aoid="SV"><a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a></emu-xref> of <emu-nt id="_ref_131"><a href="#prod-FromClause">FromClause</a></emu-nt>.</ins></li><li><ins>Return a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose sole element is the <emu-xref href="#modulerequest-record" id="_ref_34"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> { [[Specifer]]: <var>specifier</var>, [[Phase]]: <emu-const>evaluation</emu-const> }.</ins></li></ol></emu-alg>
+        <emu-alg><ol><li><del>Return <emu-xref aoid="ModuleRequests" id="_ref_35"><a href="#sec-static-semantics-modulerequests">ModuleRequests</a></emu-xref> of <emu-nt id="_ref_127"><a href="#prod-FromClause">FromClause</a></emu-nt>.</del></li><li><ins>Let <var>specifier</var> be <emu-xref aoid="SV"><a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a></emu-xref> of <emu-nt id="_ref_128"><a href="#prod-FromClause">FromClause</a></emu-nt>.</ins></li><li><ins>Return a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> whose sole element is the <emu-xref href="#modulerequest-record" id="_ref_36"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> { [[Specifer]]: <var>specifier</var>, [[Phase]]: <emu-const>evaluation</emu-const> }.</ins></li></ol></emu-alg>
         <emu-grammar><emu-production name="ExportDeclaration">
     <emu-nt><a href="https://tc39.es/ecma262/#prod-ExportDeclaration">ExportDeclaration</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="j2lh_kda">
         <emu-t>export</emu-t>
@@ -2753,9 +3539,9 @@ li.menu-search-result-term:before {
       <emu-clause id="sec-abstract-module-records">
         <h1><span class="secnum">16.1.1.4</span> Abstract Module Records</h1>
         <p>A <dfn variants="Module Records">Module Record</dfn> encapsulates structural information about the imports and exports of a single module. This information is used to link the imports and exports of sets of connected modules. A Module Record includes four fields that are only used when evaluating a module.</p>
-        <p>For specification purposes Module Record values are values of the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> specification type and can be thought of as existing in a simple object-oriented hierarchy where Module Record is an abstract class with both abstract and concrete subclasses. This specification defines the abstract subclass named <emu-xref href="#cyclic-module-record" id="_ref_35"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> and its concrete subclass named <emu-xref href="#sourctextmodule-record"><a href="https://tc39.es/ecma262/#sourctextmodule-record">Source Text Module Record</a></emu-xref>. Other specifications and implementations may define additional Module Record subclasses corresponding to alternative module definition facilities that they defined.</p>
-        <p>Module Record defines the fields listed in <emu-xref href="#table-module-record-fields" id="_ref_1"><a href="#table-module-record-fields">Table 2</a></emu-xref>. All Module Definition subclasses include at least those fields. Module Record also defines the abstract method list in <emu-xref href="#table-abstract-methods-of-module-records" id="_ref_2"><a href="#table-abstract-methods-of-module-records">Table 3</a></emu-xref>. All Module definition subclasses must provide concrete implementations of these abstract methods.</p>
-        <emu-table id="table-module-record-fields" caption="Module Record Fields" oldids="table-36"><figure><figcaption>Table 2: <emu-xref href="#sec-abstract-module-records" id="_ref_36"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> Fields</figcaption><span id="table-36"></span>
+        <p>For specification purposes Module Record values are values of the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> specification type and can be thought of as existing in a simple object-oriented hierarchy where Module Record is an abstract class with both abstract and concrete subclasses. This specification defines the abstract subclass named <emu-xref href="#cyclic-module-record" id="_ref_37"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> and its concrete subclass named <emu-xref href="#sourctextmodule-record"><a href="https://tc39.es/ecma262/#sourctextmodule-record">Source Text Module Record</a></emu-xref>. Other specifications and implementations may define additional Module Record subclasses corresponding to alternative module definition facilities that they defined.</p>
+        <p>Module Record defines the fields listed in <emu-xref href="#table-module-record-fields" id="_ref_3"><a href="#table-module-record-fields">Table 3</a></emu-xref>. All Module Definition subclasses include at least those fields. Module Record also defines the abstract method list in <emu-xref href="#table-abstract-methods-of-module-records" id="_ref_4"><a href="#table-abstract-methods-of-module-records">Table 4</a></emu-xref>. All Module definition subclasses must provide concrete implementations of these abstract methods.</p>
+        <emu-table id="table-module-record-fields" caption="Module Record Fields" oldids="table-36"><figure><figcaption>Table 3: <emu-xref href="#sec-abstract-module-records" id="_ref_38"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> Fields</figcaption><span id="table-36"></span>
           <table>
             <thead>
               <tr>
@@ -2816,7 +3602,7 @@ li.menu-search-result-term:before {
             </tr>
           </tbody></table>
         </figure></emu-table>
-        <emu-table id="table-abstract-methods-of-module-records" caption="Abstract Methods of Module Records" oldids="table-37"><figure><figcaption>Table 3: Abstract Methods of <emu-xref href="#sec-abstract-module-records" id="_ref_37"><a href="#sec-abstract-module-records">Module Records</a></emu-xref></figcaption><span id="table-37"></span>
+        <emu-table id="table-abstract-methods-of-module-records" caption="Abstract Methods of Module Records" oldids="table-37"><figure><figcaption>Table 4: Abstract Methods of <emu-xref href="#sec-abstract-module-records" id="_ref_39"><a href="#sec-abstract-module-records">Module Records</a></emu-xref></figcaption><span id="table-37"></span>
           <table>
             <tbody><tr>
               <th>
@@ -2848,7 +3634,7 @@ li.menu-search-result-term:before {
                 ResolveExport(<var>exportName</var> [, <var>resolveSet</var>])
               </td>
               <td>
-                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record" variants="ResolvedBinding Records">ResolvedBinding Record</dfn>, of the form { [[Module]]: <emu-xref href="#sec-abstract-module-records" id="_ref_38"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>, [[BindingName]]: String | <emu-const>namespace</emu-const> }. If the export is a Module Namespace Object without a direct binding in any module, [[BindingName]] will be set to <emu-const>namespace</emu-const>. Return <emu-val>null</emu-val> if the name cannot be resolved, or <emu-const>ambiguous</emu-const> if multiple bindings were found.</p>
+                <p>Return the binding of a name exported by this module. Bindings are represented by a <dfn id="resolvedbinding-record" variants="ResolvedBinding Records">ResolvedBinding Record</dfn>, of the form { [[Module]]: <emu-xref href="#sec-abstract-module-records" id="_ref_40"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>, [[BindingName]]: String | <emu-const>namespace</emu-const> }. If the export is a Module Namespace Object without a direct binding in any module, [[BindingName]] will be set to <emu-const>namespace</emu-const>. Return <emu-val>null</emu-val> if the name cannot be resolved, or <emu-const>ambiguous</emu-const> if multiple bindings were found.</p>
                 <p>Each time this operation is called with a specific <var>exportName</var>, <var>resolveSet</var> pair as arguments it must return the same result.</p>
                 <p>LoadRequestedModules must have completed successfully prior to invoking this method.</p>
               </td>
@@ -2876,9 +3662,10 @@ li.menu-search-result-term:before {
                 <ins>GetModuleSource()</ins>
               </td>
               <td>
-                <p><ins>It returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion</a></emu-xref> completion for the Module Source Object corresponding to this source <emu-xref href="#sec-abstract-module-records" id="_ref_39"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>'s source phase (<emu-xref href="#sec-module-source-objects" id="_ref_3"><a href="#sec-module-source-objects">28.1</a></emu-xref>), or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>.</ins></p>
-                <ins>When called multiple times on the same <emu-xref href="#sec-abstract-module-records" id="_ref_40"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>, if GetModuleSource() returns a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion</a></emu-xref> it must always return a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> the same object.</ins>
-                <ins>The returned object should be an instance of a subclass of <emu-xref href="#sec-%abstractmodulesource%-constructor" id="_ref_41"><a href="#sec-%abstractmodulesource%-constructor">%AbstractModuleSource%</a></emu-xref>, and it must have an internal slot [[ModuleSourceClassName]].</ins>
+                <p><ins>It returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> the Module Source Object corresponding to this source <emu-xref href="#sec-abstract-module-records" id="_ref_41"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>'s source phase (<emu-xref href="#sec-module-source-objects" id="_ref_5"><a href="#sec-module-source-objects">28.1</a></emu-xref>), or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>.</ins></p>
+                <p><ins>When called multiple times on the same <emu-xref href="#sec-abstract-module-records" id="_ref_42"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>, if GetModuleSource() returns a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion</a></emu-xref> it must always return a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> the same object.</ins></p>
+                <p><ins>The returned object should be an instance of a subclass of %AbstractModuleSource%, and it must have an internal slot [[ModuleSourceClassName]].</ins></p>
+                <p><ins>For <emu-xref href="#sec-abstract-module-records" id="_ref_43"><a href="#sec-abstract-module-records">Module Records</a></emu-xref> that do not have a source representation, GetModuleSource() must always return a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref> whose [[Value]] is a <emu-val>ReferenceError</emu-val>.</ins></p>
               </td>
             </tr>
           </tbody></table>
@@ -2888,9 +3675,9 @@ li.menu-search-result-term:before {
       <emu-clause id="sec-cyclic-module-records">
         <h1><span class="secnum">16.1.1.5</span> Cyclic Module Records</h1>
 
-        <p>A <dfn id="cyclic-module-record" variants="Cyclic Module Records">Cyclic Module Record</dfn> is used to represent information about a module that can participate in dependency cycles with other modules that are subclasses of the <emu-xref href="#cyclic-module-record" id="_ref_42"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> type. <emu-xref href="#sec-abstract-module-records" id="_ref_43"><a href="#sec-abstract-module-records">Module Records</a></emu-xref> that are not subclasses of the <emu-xref href="#cyclic-module-record" id="_ref_44"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> type must not participate in dependency cycles with <emu-xref href="#sourctextmodule-record"><a href="https://tc39.es/ecma262/#sourctextmodule-record">Source Text Module Records</a></emu-xref>.</p>
-        <p>In addition to the fields defined in <emu-xref href="#table-module-record-fields" id="_ref_4"><a href="#table-module-record-fields">Table 2</a></emu-xref> <emu-xref href="#cyclic-module-record" id="_ref_45"><a href="#cyclic-module-record">Cyclic Module Records</a></emu-xref> have the additional fields listed in <emu-xref href="#table-cyclic-module-fields" id="_ref_5"><a href="#table-cyclic-module-fields">Table 4</a></emu-xref></p>
-        <emu-table id="table-cyclic-module-fields" caption="Additional Fields of Cyclic Module Records"><figure><figcaption>Table 4: Additional Fields of <emu-xref href="#cyclic-module-record" id="_ref_46"><a href="#cyclic-module-record">Cyclic Module Records</a></emu-xref></figcaption>
+        <p>A <dfn id="cyclic-module-record" variants="Cyclic Module Records">Cyclic Module Record</dfn> is used to represent information about a module that can participate in dependency cycles with other modules that are subclasses of the <emu-xref href="#cyclic-module-record" id="_ref_44"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> type. <emu-xref href="#sec-abstract-module-records" id="_ref_45"><a href="#sec-abstract-module-records">Module Records</a></emu-xref> that are not subclasses of the <emu-xref href="#cyclic-module-record" id="_ref_46"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> type must not participate in dependency cycles with <emu-xref href="#sourctextmodule-record"><a href="https://tc39.es/ecma262/#sourctextmodule-record">Source Text Module Records</a></emu-xref>.</p>
+        <p>In addition to the fields defined in <emu-xref href="#table-module-record-fields" id="_ref_6"><a href="#table-module-record-fields">Table 3</a></emu-xref> <emu-xref href="#cyclic-module-record" id="_ref_47"><a href="#cyclic-module-record">Cyclic Module Records</a></emu-xref> have the additional fields listed in <emu-xref href="#table-cyclic-module-fields" id="_ref_7"><a href="#table-cyclic-module-fields">Table 5</a></emu-xref></p>
+        <emu-table id="table-cyclic-module-fields" caption="Additional Fields of Cyclic Module Records"><figure><figcaption>Table 5: Additional Fields of <emu-xref href="#cyclic-module-record" id="_ref_48"><a href="#cyclic-module-record">Cyclic Module Records</a></emu-xref></figcaption>
           <table>
             <tbody><tr>
               <th>
@@ -2952,10 +3739,10 @@ li.menu-search-result-term:before {
                 [[RequestedModules]]
               </td>
               <td>
-                a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <del>Strings</del><ins><emu-xref href="#modulerequest-record" id="_ref_47"><a href="#modulerequest-record">ModuleRequest Records</a></emu-xref></ins>
+                a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <del>Strings</del><ins><emu-xref href="#modulerequest-record" id="_ref_49"><a href="#modulerequest-record">ModuleRequest Records</a></emu-xref></ins>
               </td>
               <td>
-                A <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of all the <emu-nt id="_ref_132"><a href="#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt> strings used by the module represented by this record to request the importation of a module, <ins>along with their maximum associated phase (<emu-const>source</emu-const> or <emu-const>evaluation</emu-const>)</ins>. The <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> is in source text occurrence order.
+                A <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of all the <emu-nt id="_ref_129"><a href="#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt> strings used by the module represented by this record to request the importation of a module, <ins>along with their associated phase (<emu-const>source</emu-const> or <emu-const>evaluation</emu-const>)</ins>. The <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> is in source text occurrence order.
               </td>
             </tr>
             <tr>
@@ -2963,7 +3750,7 @@ li.menu-search-result-term:before {
                 [[CycleRoot]]
               </td>
               <td>
-                a <emu-xref href="#cyclic-module-record" id="_ref_48"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> or <emu-const>empty</emu-const>
+                a <emu-xref href="#cyclic-module-record" id="_ref_50"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> or <emu-const>empty</emu-const>
               </td>
               <td>
                 The first visited module of the cycle, the root DFS ancestor of the strongly connected component. For a module not in a cycle this would be the module itself. Once Evaluate has completed, a module's [[DFSAncestorIndex]] is equal to the [[DFSIndex]] of its [[CycleRoot]].
@@ -3007,7 +3794,7 @@ li.menu-search-result-term:before {
                 [[AsyncParentModules]]
               </td>
               <td>
-                a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#cyclic-module-record" id="_ref_49"><a href="#cyclic-module-record">Cyclic Module Records</a></emu-xref>
+                a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#cyclic-module-record" id="_ref_51"><a href="#cyclic-module-record">Cyclic Module Records</a></emu-xref>
               </td>
               <td>
                 If this module or a dependency has [[HasTLA]] <emu-val>true</emu-val>, and execution is in progress, this tracks the parent importers of this module for the top-level execution job. These parent modules will not start executing before this module has successfully completed execution.
@@ -3029,67 +3816,69 @@ li.menu-search-result-term:before {
 
         <emu-clause id="sec-LoadRequestedModules" type="concrete method">
           <h1><span class="secnum">16.1.1.5.1</span> LoadRequestedModules ( [ <var>hostDefined</var> ] )</h1>
-          <p>The LoadRequestedModules concrete method of a <emu-xref href="#cyclic-module-record" id="_ref_50"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> <var>module</var> takes optional argument <var>hostDefined</var> (anything) and returns a Promise object. It populates the [[LoadedModules]] of all the <emu-xref href="#sec-abstract-module-records" id="_ref_51"><a href="#sec-abstract-module-records">Module Records</a></emu-xref> in the dependency graph of <var>module</var> (most of the work is done by the auxiliary function <emu-xref aoid="InnerModuleLoading" id="_ref_52"><a href="#sec-InnerModuleLoading">InnerModuleLoading</a></emu-xref>). It takes an optional <var>hostDefined</var> parameter that is passed to the <emu-xref aoid="HostLoadImportedModule" id="_ref_53"><a href="#sec-HostLoadImportedModule">HostLoadImportedModule</a></emu-xref> hook.</p>
+          <p>The LoadRequestedModules concrete method of a <emu-xref href="#cyclic-module-record" id="_ref_52"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> <var>module</var> takes optional argument <var>hostDefined</var> (anything) and returns a Promise object. It populates the [[LoadedModules]] of all the <emu-xref href="#sec-abstract-module-records" id="_ref_53"><a href="#sec-abstract-module-records">Module Records</a></emu-xref> in the dependency graph of <var>module</var> (most of the work is done by the auxiliary function <emu-xref aoid="InnerModuleLoading" id="_ref_54"><a href="#sec-InnerModuleLoading">InnerModuleLoading</a></emu-xref>). It takes an optional <var>hostDefined</var> parameter that is passed to the <emu-xref aoid="HostLoadImportedModule" id="_ref_55"><a href="#sec-HostLoadImportedModule">HostLoadImportedModule</a></emu-xref> hook. It performs the following steps when called:</p>
+          <emu-alg><ol><li>If <var>hostDefined</var> is not present, let <var>hostDefined</var> be <emu-const>empty</emu-const>.</li><li>Let <var>pc</var> be !&nbsp;<emu-xref aoid="NewPromiseCapability"><a href="https://tc39.es/ecma262/#sec-newpromisecapability">NewPromiseCapability</a></emu-xref>(<emu-xref href="#sec-promise-constructor"><a href="https://tc39.es/ecma262/#sec-promise-constructor">%Promise%</a></emu-xref>).</li><li>Let <var>state</var> be the <emu-xref href="#graphloadingstate-record"><a href="https://tc39.es/ecma262/#graphloadingstate-record">GraphLoadingState Record</a></emu-xref> { [[IsLoading]]: <emu-val>true</emu-val>, [[PendingModulesCount]]: 1, [[Visited]]: « », [[PromiseCapability]]: <var>pc</var>, [[HostDefined]]: <var>hostDefined</var> }.</li><li>Perform <emu-xref aoid="InnerModuleLoading" id="_ref_56"><a href="#sec-InnerModuleLoading">InnerModuleLoading</a></emu-xref>(<var>state</var>, <var>module</var><ins>, <emu-const>recursive-load</emu-const></ins>).</li><li>Return <var>pc</var>.[[Promise]].</li></ol></emu-alg>
 
           <emu-clause id="sec-InnerModuleLoading" type="abstract operation" aoid="InnerModuleLoading">
-            <h1><span class="secnum">16.1.1.5.1.1</span> InnerModuleLoading ( <var>state</var>, <var>module</var>, <ins><var>phase</var></ins> )</h1>
-            <p>The abstract operation InnerModuleLoading takes arguments <var>state</var> (a <emu-xref href="#graphloadingstate-record"><a href="https://tc39.es/ecma262/#graphloadingstate-record">GraphLoadingState Record</a></emu-xref>), <var>module</var> (a <emu-xref href="#sec-abstract-module-records" id="_ref_54"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>), and <ins><var>phase</var> (<emu-const>source</emu-const> or <emu-const>evaluation</emu-const>)</ins> and returns <emu-const>unused</emu-const>. It is used by LoadRequestedModules to recursively perform the actual loading process for <var>module</var>'s dependency graph. It performs the following steps when called:</p>
+            <h1><span class="secnum">16.1.1.5.1.1</span> InnerModuleLoading ( <var>state</var>, <var>module</var>, <ins><var>loadType</var></ins> )</h1>
+            <p>The abstract operation InnerModuleLoading takes arguments <var>state</var> (a <emu-xref href="#graphloadingstate-record"><a href="https://tc39.es/ecma262/#graphloadingstate-record">GraphLoadingState Record</a></emu-xref>), <var>module</var> (a <emu-xref href="#sec-abstract-module-records" id="_ref_57"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>), and <ins><var>loadType</var> (<emu-const>single</emu-const> or <emu-const>recursive-load</emu-const>)</ins> and returns <emu-const>unused</emu-const>. It is used by LoadRequestedModules to recursively perform the actual loading process for <var>module</var>'s dependency graph. It performs the following steps when called:</p>
 
-            <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>state</var>.[[IsLoading]] is <emu-val>true</emu-val>.</li><li>If <var>module</var> is a <emu-xref href="#cyclic-module-record" id="_ref_55"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>, <var>module</var>.[[Status]] is <emu-const>new</emu-const>, <del>and</del> <var>state</var>.[[Visited]] does not contain <var>module</var><ins>, and <var>phase</var> is <emu-const>evaluation</emu-const>, </ins>then<ol><li>Append <var>module</var> to <var>state</var>.[[Visited]].</li><li>Let <var>requestedModulesCount</var> be the number of elements in <var>module</var>.[[RequestedModules]].</li><li>Set <var>state</var>.[[PendingModulesCount]] to <var>state</var>.[[PendingModulesCount]] + <var>requestedModulesCount</var>.</li><li><del>For each String <var>required</var> of <var>module</var>.[[RequestedModules]], do</del></li><li><ins>For each <emu-xref href="#modulerequest-record" id="_ref_56"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> <var>required</var> of <var>module</var>.[[RequestedModules]], do</ins><ol><li>If <var>module</var>.[[LoadedModules]] contains a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> whose [[Specifier]] is <var>required</var><ins>.[[Specifier]]</ins>, then<ol><li>Let <var>record</var> be that <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>Perform <emu-xref aoid="InnerModuleLoading" id="_ref_57"><a href="#sec-InnerModuleLoading">InnerModuleLoading</a></emu-xref>(<var>state</var>, <var>record</var>.[[Module]], <ins><var>required</var>.[[Phase]]</ins>).</li></ol></li><li>Else,<ol><li>Perform <emu-xref aoid="HostLoadImportedModule" id="_ref_58"><a href="#sec-HostLoadImportedModule">HostLoadImportedModule</a></emu-xref>(<var>module</var>, <var>required</var>, <var>state</var>.[[HostDefined]], <var>state</var>).</li><li>NOTE: <emu-xref aoid="HostLoadImportedModule" id="_ref_59"><a href="#sec-HostLoadImportedModule">HostLoadImportedModule</a></emu-xref> will call <emu-xref aoid="FinishLoadingImportedModule" id="_ref_60"><a href="#sec-FinishLoadingImportedModule">FinishLoadingImportedModule</a></emu-xref>, which re-enters the graph loading process through <emu-xref aoid="ContinueModuleLoading" id="_ref_61"><a href="#sec-ContinueModuleLoading">ContinueModuleLoading</a></emu-xref>.</li></ol></li><li>If <var>state</var>.[[IsLoading]] is <emu-val>false</emu-val>, return <emu-const>unused</emu-const>.</li></ol></li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>state</var>.[[PendingModulesCount]] ≥ 1.</li><li>Set <var>state</var>.[[PendingModulesCount]] to <var>state</var>.[[PendingModulesCount]] - 1.</li><li>If <var>state</var>.[[PendingModulesCount]] = 0, then<ol><li>Set <var>state</var>.[[IsLoading]] to <emu-val>false</emu-val>.</li><li>For each <emu-xref href="#cyclic-module-record" id="_ref_62"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> <var>loaded</var> of <var>state</var>.[[Visited]], do<ol><li>If <var>loaded</var>.[[Status]] is <emu-const>new</emu-const>, set <var>loaded</var>.[[Status]] to <emu-const>unlinked</emu-const>.</li></ol></li><li>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>state</var>.[[PromiseCapability]].[[Resolve]], <emu-val>undefined</emu-val>, « <emu-val>undefined</emu-val> »).</li></ol></li><li>Return <emu-const>unused</emu-const>.</li></ol></emu-alg>
+            <emu-alg><ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>state</var>.[[IsLoading]] is <emu-val>true</emu-val>.</li><li>If <ins><var>loadType</var> is <emu-const>recursive-load</emu-const>, </ins><var>module</var> is a <emu-xref href="#cyclic-module-record" id="_ref_58"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>, <var>module</var>.[[Status]] is <emu-const>new</emu-const>, and <var>state</var>.[[Visited]] does not contain <var>module</var>, then<ol><li>Append <var>module</var> to <var>state</var>.[[Visited]].</li><li>Let <var>requestedModulesCount</var> be the number of elements in <var>module</var>.[[RequestedModules]].</li><li>Set <var>state</var>.[[PendingModulesCount]] to <var>state</var>.[[PendingModulesCount]] + <var>requestedModulesCount</var>.</li><li><del>For each String <var>required</var> of <var>module</var>.[[RequestedModules]], do</del></li><li><ins>For each <emu-xref href="#modulerequest-record" id="_ref_59"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> <var>required</var> of <var>module</var>.[[RequestedModules]], do</ins><ol><li>If <var>module</var>.[[LoadedModules]] contains a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> whose [[Specifier]] is <var>required</var><ins>.[[Specifier]]</ins>, then<ol><li>Let <var>record</var> be that <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li><ins>If <var>required</var>.[[Phase]] is <emu-const>source</emu-const>, let <var>innerLoadType</var> be <emu-const>single</emu-const>; otherwise let <var>innerLoadType</var> be <emu-const>recursive-load</emu-const>.</ins></li><li>Perform <emu-xref aoid="InnerModuleLoading" id="_ref_60"><a href="#sec-InnerModuleLoading">InnerModuleLoading</a></emu-xref>(<var>state</var>, <var>record</var>.[[Module]], <ins><var>innerLoadType</var></ins>).</li></ol></li><li>Else,<ol><li>Perform <emu-xref aoid="HostLoadImportedModule" id="_ref_61"><a href="#sec-HostLoadImportedModule">HostLoadImportedModule</a></emu-xref>(<var>module</var>, <var>required</var>, <var>state</var>.[[HostDefined]], <var>state</var>).</li><li>NOTE: <emu-xref aoid="HostLoadImportedModule" id="_ref_62"><a href="#sec-HostLoadImportedModule">HostLoadImportedModule</a></emu-xref> will call <emu-xref aoid="FinishLoadingImportedModule" id="_ref_63"><a href="#sec-FinishLoadingImportedModule">FinishLoadingImportedModule</a></emu-xref>, which re-enters the graph loading process through <emu-xref aoid="ContinueModuleLoading" id="_ref_64"><a href="#sec-ContinueModuleLoading">ContinueModuleLoading</a></emu-xref>.</li></ol></li><li>If <var>state</var>.[[IsLoading]] is <emu-val>false</emu-val>, return <emu-const>unused</emu-const>.</li></ol></li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>state</var>.[[PendingModulesCount]] ≥ 1.</li><li>Set <var>state</var>.[[PendingModulesCount]] to <var>state</var>.[[PendingModulesCount]] - 1.</li><li>If <var>state</var>.[[PendingModulesCount]] = 0, then<ol><li>Set <var>state</var>.[[IsLoading]] to <emu-val>false</emu-val>.</li><li>For each <emu-xref href="#cyclic-module-record" id="_ref_65"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> <var>loaded</var> of <var>state</var>.[[Visited]], do<ol><li>If <var>loaded</var>.[[Status]] is <emu-const>new</emu-const>, set <var>loaded</var>.[[Status]] to <emu-const>unlinked</emu-const>.</li></ol></li><li>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>state</var>.[[PromiseCapability]].[[Resolve]], <emu-val>undefined</emu-val>, « <emu-val>undefined</emu-val> »).</li></ol></li><li>Return <emu-const>unused</emu-const>.</li></ol></emu-alg>
           </emu-clause>
 
           <emu-clause id="sec-ContinueModuleLoading" type="abstract operation" aoid="ContinueModuleLoading">
             <h1><span class="secnum">16.1.1.5.1.2</span> ContinueModuleLoading ( <var>state</var>, <ins><var>phase</var></ins>, <var>moduleCompletion</var> )</h1>
-            <p>The abstract operation ContinueModuleLoading takes arguments <var>state</var> (a <emu-xref href="#graphloadingstate-record"><a href="https://tc39.es/ecma262/#graphloadingstate-record">GraphLoadingState Record</a></emu-xref>), <ins><var>phase</var> (<emu-const>source</emu-const> or <emu-const>evaluation</emu-const>)</ins>, and <var>moduleCompletion</var> (either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a <emu-xref href="#sec-abstract-module-records" id="_ref_63"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>) and returns <emu-const>unused</emu-const>. It is used to re-enter the loading process after a call to <emu-xref aoid="HostLoadImportedModule" id="_ref_64"><a href="#sec-HostLoadImportedModule">HostLoadImportedModule</a></emu-xref>. It performs the following steps when called:</p>
+            <p>The abstract operation ContinueModuleLoading takes arguments <var>state</var> (a <emu-xref href="#graphloadingstate-record"><a href="https://tc39.es/ecma262/#graphloadingstate-record">GraphLoadingState Record</a></emu-xref>), <ins><var>phase</var> (<emu-const>source</emu-const> or <emu-const>evaluation</emu-const>)</ins>, and <var>moduleCompletion</var> (either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a <emu-xref href="#sec-abstract-module-records" id="_ref_66"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>) and returns <emu-const>unused</emu-const>. It is used to re-enter the loading process after a call to <emu-xref aoid="HostLoadImportedModule" id="_ref_67"><a href="#sec-HostLoadImportedModule">HostLoadImportedModule</a></emu-xref>. It performs the following steps when called:</p>
 
-            <emu-alg><ol><li>If <var>state</var>.[[IsLoading]] is <emu-val>false</emu-val>, return <emu-const>unused</emu-const>.</li><li>If <var>moduleCompletion</var> is a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion</a></emu-xref>, then<ol><li>Perform <emu-xref aoid="InnerModuleLoading" id="_ref_65"><a href="#sec-InnerModuleLoading">InnerModuleLoading</a></emu-xref>(<var>state</var>, <var>moduleCompletion</var>.[[Value]]<ins>, <var>phase</var></ins>).</li></ol></li><li>Else,<ol><li>Set <var>state</var>.[[IsLoading]] to <emu-val>false</emu-val>.</li><li>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>state</var>.[[PromiseCapability]].[[Reject]], <emu-val>undefined</emu-val>, « <var>moduleCompletion</var>.[[Value]] »).</li></ol></li><li>Return <emu-const>unused</emu-const>.</li></ol></emu-alg>
+            <emu-alg><ol><li>If <var>state</var>.[[IsLoading]] is <emu-val>false</emu-val>, return <emu-const>unused</emu-const>.</li><li>If <var>moduleCompletion</var> is a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion</a></emu-xref>, then<ol><li><ins>If <var>phase</var> is <emu-const>source</emu-const>, let <var>loadType</var> be <emu-const>single</emu-const>; otherwise let <var>loadType</var> be <emu-const>recursive-load</emu-const>.</ins></li><li>Perform <emu-xref aoid="InnerModuleLoading" id="_ref_68"><a href="#sec-InnerModuleLoading">InnerModuleLoading</a></emu-xref>(<var>state</var>, <var>moduleCompletion</var>.[[Value]]<ins>, <var>loadType</var></ins>).</li></ol></li><li>Else,<ol><li>Set <var>state</var>.[[IsLoading]] to <emu-val>false</emu-val>.</li><li>Perform !&nbsp;<emu-xref aoid="Call"><a href="https://tc39.es/ecma262/#sec-call">Call</a></emu-xref>(<var>state</var>.[[PromiseCapability]].[[Reject]], <emu-val>undefined</emu-val>, « <var>moduleCompletion</var>.[[Value]] »).</li></ol></li><li>Return <emu-const>unused</emu-const>.</li></ol></emu-alg>
           </emu-clause>
         </emu-clause>
 
         <emu-clause id="sec-moduledeclarationlinking" type="concrete method" oldids="sec-moduledeclarationinstantiation"><span id="sec-moduledeclarationinstantiation"></span>
           <h1><span class="secnum">16.1.1.5.2</span> Link ( )</h1>
-          <p>The Link concrete method of a <emu-xref href="#cyclic-module-record" id="_ref_66"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> <var>module</var> takes no arguments and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> <emu-const>unused</emu-const> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. On success, Link transitions this module's [[Status]] from <emu-const>unlinked</emu-const> to <emu-const>linked</emu-const>. On failure, an exception is thrown and this module's [[Status]] remains <emu-const>unlinked</emu-const>. (Most of the work is done by the auxiliary function <emu-xref aoid="InnerModuleLinking" id="_ref_67"><a href="#sec-InnerModuleLinking">InnerModuleLinking</a></emu-xref>.)</p>
+          <p>The Link concrete method of a <emu-xref href="#cyclic-module-record" id="_ref_69"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> <var>module</var> takes no arguments and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> <emu-const>unused</emu-const> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. On success, Link transitions this module's [[Status]] from <emu-const>unlinked</emu-const> to <emu-const>linked</emu-const>. On failure, an exception is thrown and this module's [[Status]] remains <emu-const>unlinked</emu-const>. (Most of the work is done by the auxiliary function <emu-xref aoid="InnerModuleLinking" id="_ref_70"><a href="#sec-InnerModuleLinking">InnerModuleLinking</a></emu-xref>.)</p>
 
           <emu-clause id="sec-InnerModuleLinking" type="abstract operation" oldids="sec-innermoduleinstantiation" aoid="InnerModuleLinking"><span id="sec-innermoduleinstantiation"></span>
             <h1><span class="secnum">16.1.1.5.2.1</span> InnerModuleLinking ( <var>module</var>, <var>stack</var>, <var>index</var> )</h1>
-            <p>The abstract operation InnerModuleLinking takes arguments <var>module</var> (a <emu-xref href="#sec-abstract-module-records" id="_ref_68"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>), <var>stack</var> (a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#cyclic-module-record" id="_ref_69"><a href="#cyclic-module-record">Cyclic Module Records</a></emu-xref>), and <var>index</var> (a non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. It is used by Link to perform the actual linking process for <var>module</var>, as well as recursively on all other modules in the dependency graph. The <var>stack</var> and <var>index</var> parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to <emu-const>linked</emu-const> together. It performs the following steps when called:</p>
+            <p>The abstract operation InnerModuleLinking takes arguments <var>module</var> (a <emu-xref href="#sec-abstract-module-records" id="_ref_71"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>), <var>stack</var> (a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#cyclic-module-record" id="_ref_72"><a href="#cyclic-module-record">Cyclic Module Records</a></emu-xref>), and <var>index</var> (a non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. It is used by Link to perform the actual linking process for <var>module</var>, as well as recursively on all other modules in the dependency graph. The <var>stack</var> and <var>index</var> parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to <emu-const>linked</emu-const> together. It performs the following steps when called:</p>
 
-            <emu-alg><ol><li>If <var>module</var> is not a <emu-xref href="#cyclic-module-record" id="_ref_70"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>, then<ol><li>Perform ?&nbsp;<var>module</var>.Link().</li><li>Return <var>index</var>.</li></ol></li><li>If <var>module</var>.[[Status]] is one of <emu-const>linking</emu-const>, <emu-const>linked</emu-const>, <emu-const>evaluating-async</emu-const>, or <emu-const>evaluated</emu-const>, then<ol><li>Return <var>index</var>.</li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var>.[[Status]] is <emu-const>unlinked</emu-const>.</li><li>Set <var>module</var>.[[Status]] to <emu-const>linking</emu-const>.</li><li>Set <var>module</var>.[[DFSIndex]] to <var>index</var>.</li><li>Set <var>module</var>.[[DFSAncestorIndex]] to <var>index</var>.</li><li>Set <var>index</var> to <var>index</var> + 1.</li><li>Append <var>module</var> to <var>stack</var>.</li><li>For each <del>String</del><ins><emu-xref href="#modulerequest-record" id="_ref_71"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref></ins> <var>required</var> of <var>module</var>.[[RequestedModules]], do<ol><li><ins>If <var>required</var>.[[Phase]] is <emu-const>evaluation</emu-const>, then</ins><ol><li>Let <var>requiredModule</var> be <emu-xref aoid="GetImportedModule"><a href="https://tc39.es/ecma262/#sec-GetImportedModule">GetImportedModule</a></emu-xref>(<var>module</var>, <var>required</var><ins>.[[Specifier]]</ins>).</li><li>Set <var>index</var> to ?&nbsp;<emu-xref aoid="InnerModuleLinking" id="_ref_72"><a href="#sec-InnerModuleLinking">InnerModuleLinking</a></emu-xref>(<var>requiredModule</var>, <var>stack</var>, <var>index</var>).</li><li>If <var>requiredModule</var> is a <emu-xref href="#cyclic-module-record" id="_ref_73"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>, then<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>requiredModule</var>.[[Status]] is one of <emu-const>linking</emu-const>, <emu-const>linked</emu-const>, <emu-const>evaluating-async</emu-const>, or <emu-const>evaluated</emu-const>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>requiredModule</var>.[[Status]] is <emu-const>linking</emu-const> if and only if <var>stack</var> contains <var>requiredModule</var>.</li><li>If <var>requiredModule</var>.[[Status]] is <emu-const>linking</emu-const>, then<ol><li>Set <var>module</var>.[[DFSAncestorIndex]] to <emu-xref aoid="min"><a href="https://tc39.es/ecma262/#eqn-min">min</a></emu-xref>(<var>module</var>.[[DFSAncestorIndex]], <var>requiredModule</var>.[[DFSAncestorIndex]]).</li></ol></li></ol></li></ol></li></ol></li><li>Perform ?&nbsp;<var>module</var>.InitializeEnvironment().</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var> occurs exactly once in <var>stack</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var>.[[DFSAncestorIndex]] ≤ <var>module</var>.[[DFSIndex]].</li><li>If <var>module</var>.[[DFSAncestorIndex]] = <var>module</var>.[[DFSIndex]], then<ol><li>Let <var>done</var> be <emu-val>false</emu-val>.</li><li>Repeat, while <var>done</var> is <emu-val>false</emu-val>,<ol><li>Let <var>requiredModule</var> be the last element of <var>stack</var>.</li><li>Remove the last element of <var>stack</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>requiredModule</var> is a <emu-xref href="#cyclic-module-record" id="_ref_74"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>.</li><li>Set <var>requiredModule</var>.[[Status]] to <emu-const>linked</emu-const>.</li><li>If <var>requiredModule</var> and <var>module</var> are the same <emu-xref href="#sec-abstract-module-records" id="_ref_75"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>, set <var>done</var> to <emu-val>true</emu-val>.</li></ol></li></ol></li><li>Return <var>index</var>.</li></ol></emu-alg>
+            <emu-alg><ol><li>If <var>module</var> is not a <emu-xref href="#cyclic-module-record" id="_ref_73"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>, then<ol><li>Perform ?&nbsp;<var>module</var>.Link().</li><li>Return <var>index</var>.</li></ol></li><li>If <var>module</var>.[[Status]] is one of <emu-const>linking</emu-const>, <emu-const>linked</emu-const>, <emu-const>evaluating-async</emu-const>, or <emu-const>evaluated</emu-const>, then<ol><li>Return <var>index</var>.</li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var>.[[Status]] is <emu-const>unlinked</emu-const>.</li><li>Set <var>module</var>.[[Status]] to <emu-const>linking</emu-const>.</li><li>Set <var>module</var>.[[DFSIndex]] to <var>index</var>.</li><li>Set <var>module</var>.[[DFSAncestorIndex]] to <var>index</var>.</li><li>Set <var>index</var> to <var>index</var> + 1.</li><li>Append <var>module</var> to <var>stack</var>.</li><li>For each <del>String</del><ins><emu-xref href="#modulerequest-record" id="_ref_74"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref></ins> <var>required</var> of <var>module</var>.[[RequestedModules]], do<ol><li><ins>If <var>required</var>.[[Phase]] is <emu-const>evaluation</emu-const>, then</ins><ol><li>Let <var>requiredModule</var> be <emu-xref aoid="GetImportedModule"><a href="https://tc39.es/ecma262/#sec-GetImportedModule">GetImportedModule</a></emu-xref>(<var>module</var>, <var>required</var><ins>.[[Specifier]]</ins>).</li><li>Set <var>index</var> to ?&nbsp;<emu-xref aoid="InnerModuleLinking" id="_ref_75"><a href="#sec-InnerModuleLinking">InnerModuleLinking</a></emu-xref>(<var>requiredModule</var>, <var>stack</var>, <var>index</var>).</li><li>If <var>requiredModule</var> is a <emu-xref href="#cyclic-module-record" id="_ref_76"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>, then<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>requiredModule</var>.[[Status]] is one of <emu-const>linking</emu-const>, <emu-const>linked</emu-const>, <emu-const>evaluating-async</emu-const>, or <emu-const>evaluated</emu-const>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>requiredModule</var>.[[Status]] is <emu-const>linking</emu-const> if and only if <var>stack</var> contains <var>requiredModule</var>.</li><li>If <var>requiredModule</var>.[[Status]] is <emu-const>linking</emu-const>, then<ol><li>Set <var>module</var>.[[DFSAncestorIndex]] to <emu-xref aoid="min"><a href="https://tc39.es/ecma262/#eqn-min">min</a></emu-xref>(<var>module</var>.[[DFSAncestorIndex]], <var>requiredModule</var>.[[DFSAncestorIndex]]).</li></ol></li></ol></li></ol></li></ol></li><li>Perform ?&nbsp;<var>module</var>.InitializeEnvironment().</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var> occurs exactly once in <var>stack</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var>.[[DFSAncestorIndex]] ≤ <var>module</var>.[[DFSIndex]].</li><li>If <var>module</var>.[[DFSAncestorIndex]] = <var>module</var>.[[DFSIndex]], then<ol><li>Let <var>done</var> be <emu-val>false</emu-val>.</li><li>Repeat, while <var>done</var> is <emu-val>false</emu-val>,<ol><li>Let <var>requiredModule</var> be the last element of <var>stack</var>.</li><li>Remove the last element of <var>stack</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>requiredModule</var> is a <emu-xref href="#cyclic-module-record" id="_ref_77"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>.</li><li>Set <var>requiredModule</var>.[[Status]] to <emu-const>linked</emu-const>.</li><li>If <var>requiredModule</var> and <var>module</var> are the same <emu-xref href="#sec-abstract-module-records" id="_ref_78"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>, set <var>done</var> to <emu-val>true</emu-val>.</li></ol></li></ol></li><li>Return <var>index</var>.</li></ol></emu-alg>
           </emu-clause>
         </emu-clause>
         <emu-clause id="sec-moduleevaluation" type="concrete method">
           <h1><span class="secnum">16.1.1.5.3</span> Evaluate ( )</h1>
-          <p>The Evaluate concrete method of a <emu-xref href="#cyclic-module-record" id="_ref_76"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> <var>module</var> takes no arguments and returns a Promise. Evaluate transitions this module's [[Status]] from <emu-const>linked</emu-const> to either <emu-const>evaluating-async</emu-const> or <emu-const>evaluated</emu-const>. The first time it is called on a module in a given strongly connected component, Evaluate creates and returns a Promise which resolves when the module has finished evaluating. This Promise is stored in the [[TopLevelCapability]] field of the [[CycleRoot]] for the component. Future invocations of Evaluate on any module in the component return the same Promise. (Most of the work is done by the auxiliary function <emu-xref aoid="InnerModuleEvaluation" id="_ref_77"><a href="#sec-innermoduleevaluation">InnerModuleEvaluation</a></emu-xref>.)</p>
+          <p>The Evaluate concrete method of a <emu-xref href="#cyclic-module-record" id="_ref_79"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> <var>module</var> takes no arguments and returns a Promise. Evaluate transitions this module's [[Status]] from <emu-const>linked</emu-const> to either <emu-const>evaluating-async</emu-const> or <emu-const>evaluated</emu-const>. The first time it is called on a module in a given strongly connected component, Evaluate creates and returns a Promise which resolves when the module has finished evaluating. This Promise is stored in the [[TopLevelCapability]] field of the [[CycleRoot]] for the component. Future invocations of Evaluate on any module in the component return the same Promise. (Most of the work is done by the auxiliary function <emu-xref aoid="InnerModuleEvaluation" id="_ref_80"><a href="#sec-innermoduleevaluation">InnerModuleEvaluation</a></emu-xref>.)</p>
 
           <emu-clause id="sec-innermoduleevaluation" type="abstract operation" aoid="InnerModuleEvaluation">
             <h1><span class="secnum">16.1.1.5.3.1</span> InnerModuleEvaluation ( <var>module</var>, <var>stack</var>, <var>index</var> )</h1>
-            <p>The abstract operation InnerModuleEvaluation takes arguments <var>module</var> (a <emu-xref href="#sec-abstract-module-records" id="_ref_78"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>), <var>stack</var> (a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#cyclic-module-record" id="_ref_79"><a href="#cyclic-module-record">Cyclic Module Records</a></emu-xref>), and <var>index</var> (a non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. It is used by Evaluate to perform the actual evaluation process for <var>module</var>, as well as recursively on all other modules in the dependency graph. The <var>stack</var> and <var>index</var> parameters, as well as <var>module</var>'s [[DFSIndex]] and [[DFSAncestorIndex]] fields, are used the same way as in <emu-xref aoid="InnerModuleLinking" id="_ref_80"><a href="#sec-InnerModuleLinking">InnerModuleLinking</a></emu-xref>. It performs the following steps when called:</p>
+            <p>The abstract operation InnerModuleEvaluation takes arguments <var>module</var> (a <emu-xref href="#sec-abstract-module-records" id="_ref_81"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>), <var>stack</var> (a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#cyclic-module-record" id="_ref_82"><a href="#cyclic-module-record">Cyclic Module Records</a></emu-xref>), and <var>index</var> (a non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref>) and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a non-negative <emu-xref href="#integer"><a href="https://tc39.es/ecma262/#integer">integer</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. It is used by Evaluate to perform the actual evaluation process for <var>module</var>, as well as recursively on all other modules in the dependency graph. The <var>stack</var> and <var>index</var> parameters, as well as <var>module</var>'s [[DFSIndex]] and [[DFSAncestorIndex]] fields, are used the same way as in <emu-xref aoid="InnerModuleLinking" id="_ref_83"><a href="#sec-InnerModuleLinking">InnerModuleLinking</a></emu-xref>. It performs the following steps when called:</p>
 
-            <emu-alg><ol><li>If <var>module</var> is not a <emu-xref href="#cyclic-module-record" id="_ref_81"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>, then<ol><li>Let <var>promise</var> be !&nbsp;<var>module</var>.Evaluate().</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>promise</var>.[[PromiseState]] is not <emu-const>pending</emu-const>.</li><li>If <var>promise</var>.[[PromiseState]] is <emu-const>rejected</emu-const>, then<ol><li>Return <emu-xref aoid="ThrowCompletion"><a href="https://tc39.es/ecma262/#sec-throwcompletion">ThrowCompletion</a></emu-xref>(<var>promise</var>.[[PromiseResult]]).</li></ol></li><li>Return <var>index</var>.</li></ol></li><li>If <var>module</var>.[[Status]] is either <emu-const>evaluating-async</emu-const> or <emu-const>evaluated</emu-const>, then<ol><li>If <var>module</var>.[[EvaluationError]] is <emu-const>empty</emu-const>, return <var>index</var>.</li><li>Otherwise, return ?&nbsp;<var>module</var>.[[EvaluationError]].</li></ol></li><li>If <var>module</var>.[[Status]] is <emu-const>evaluating</emu-const>, return <var>index</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var>.[[Status]] is <emu-const>linked</emu-const>.</li><li>Set <var>module</var>.[[Status]] to <emu-const>evaluating</emu-const>.</li><li>Set <var>module</var>.[[DFSIndex]] to <var>index</var>.</li><li>Set <var>module</var>.[[DFSAncestorIndex]] to <var>index</var>.</li><li>Set <var>module</var>.[[PendingAsyncDependencies]] to 0.</li><li>Set <var>index</var> to <var>index</var> + 1.</li><li>Append <var>module</var> to <var>stack</var>.</li><li><del>For each String <var>required</var> of <var>module</var>.[[RequestedModules]], do</del></li><li><ins>For each <emu-xref href="#modulerequest-record" id="_ref_82"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> <var>required</var> of <var>module</var>.[[RequestedModules]], do</ins><ol><li>Let <var>requiredModule</var> be <emu-xref aoid="GetImportedModule"><a href="https://tc39.es/ecma262/#sec-GetImportedModule">GetImportedModule</a></emu-xref>(<var>module</var>, <var>required</var><ins>.[[Specifier]]</ins>).</li><li><ins>If <var>requiredModule</var>.[[Phase]] is <emu-const>evaluation</emu-const>, then</ins><ol><li>Set <var>index</var> to ?&nbsp;<emu-xref aoid="InnerModuleEvaluation" id="_ref_83"><a href="#sec-innermoduleevaluation">InnerModuleEvaluation</a></emu-xref>(<var>requiredModule</var>, <var>stack</var>, <var>index</var>).</li><li>If <var>requiredModule</var> is a <emu-xref href="#cyclic-module-record" id="_ref_84"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>, then<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>requiredModule</var>.[[Status]] is one of <emu-const>evaluating</emu-const>, <emu-const>evaluating-async</emu-const>, or <emu-const>evaluated</emu-const>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>requiredModule</var>.[[Status]] is <emu-const>evaluating</emu-const> if and only if <var>stack</var> contains <var>requiredModule</var>.</li><li>If <var>requiredModule</var>.[[Status]] is <emu-const>evaluating</emu-const>, then<ol><li>Set <var>module</var>.[[DFSAncestorIndex]] to <emu-xref aoid="min"><a href="https://tc39.es/ecma262/#eqn-min">min</a></emu-xref>(<var>module</var>.[[DFSAncestorIndex]], <var>requiredModule</var>.[[DFSAncestorIndex]]).</li></ol></li><li>Else,<ol><li>Set <var>requiredModule</var> to <var>requiredModule</var>.[[CycleRoot]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>requiredModule</var>.[[Status]] is either <emu-const>evaluating-async</emu-const> or <emu-const>evaluated</emu-const>.</li><li>If <var>requiredModule</var>.[[EvaluationError]] is not <emu-const>empty</emu-const>, return ?&nbsp;<var>requiredModule</var>.[[EvaluationError]].</li></ol></li><li>If <var>requiredModule</var>.[[AsyncEvaluation]] is <emu-val>true</emu-val>, then<ol><li>Set <var>module</var>.[[PendingAsyncDependencies]] to <var>module</var>.[[PendingAsyncDependencies]] + 1.</li><li>Append <var>module</var> to <var>requiredModule</var>.[[AsyncParentModules]].</li></ol></li></ol></li></ol></li></ol></li><li>If <var>module</var>.[[PendingAsyncDependencies]] &gt; 0 or <var>module</var>.[[HasTLA]] is <emu-val>true</emu-val>, then<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var>.[[AsyncEvaluation]] is <emu-val>false</emu-val> and was never previously set to <emu-val>true</emu-val>.</li><li>Set <var>module</var>.[[AsyncEvaluation]] to <emu-val>true</emu-val>.</li><li>NOTE: The order in which module records have their [[AsyncEvaluation]] fields transition to <emu-val>true</emu-val> is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"><a href="https://tc39.es/ecma262/#sec-async-module-execution-fulfilled">16.2.1.5.3.4</a></emu-xref>.)</li><li>If <var>module</var>.[[PendingAsyncDependencies]] = 0, perform <emu-xref aoid="ExecuteAsyncModule"><a href="https://tc39.es/ecma262/#sec-execute-async-module">ExecuteAsyncModule</a></emu-xref>(<var>module</var>).</li></ol></li><li>Else,<ol><li>Perform ?&nbsp;<var>module</var>.ExecuteModule().</li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var> occurs exactly once in <var>stack</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var>.[[DFSAncestorIndex]] ≤ <var>module</var>.[[DFSIndex]].</li><li>If <var>module</var>.[[DFSAncestorIndex]] = <var>module</var>.[[DFSIndex]], then<ol><li>Let <var>done</var> be <emu-val>false</emu-val>.</li><li>Repeat, while <var>done</var> is <emu-val>false</emu-val>,<ol><li>Let <var>requiredModule</var> be the last element of <var>stack</var>.</li><li>Remove the last element of <var>stack</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>requiredModule</var> is a <emu-xref href="#cyclic-module-record" id="_ref_85"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>.</li><li>If <var>requiredModule</var>.[[AsyncEvaluation]] is <emu-val>false</emu-val>, set <var>requiredModule</var>.[[Status]] to <emu-const>evaluated</emu-const>.</li><li>Otherwise, set <var>requiredModule</var>.[[Status]] to <emu-const>evaluating-async</emu-const>.</li><li>If <var>requiredModule</var> and <var>module</var> are the same <emu-xref href="#sec-abstract-module-records" id="_ref_86"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>, set <var>done</var> to <emu-val>true</emu-val>.</li><li>Set <var>requiredModule</var>.[[CycleRoot]] to <var>module</var>.</li></ol></li></ol></li><li>Return <var>index</var>.</li></ol></emu-alg>
+            <emu-alg><ol><li>If <var>module</var> is not a <emu-xref href="#cyclic-module-record" id="_ref_84"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>, then<ol><li>Let <var>promise</var> be !&nbsp;<var>module</var>.Evaluate().</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>promise</var>.[[PromiseState]] is not <emu-const>pending</emu-const>.</li><li>If <var>promise</var>.[[PromiseState]] is <emu-const>rejected</emu-const>, then<ol><li>Return <emu-xref aoid="ThrowCompletion"><a href="https://tc39.es/ecma262/#sec-throwcompletion">ThrowCompletion</a></emu-xref>(<var>promise</var>.[[PromiseResult]]).</li></ol></li><li>Return <var>index</var>.</li></ol></li><li>If <var>module</var>.[[Status]] is either <emu-const>evaluating-async</emu-const> or <emu-const>evaluated</emu-const>, then<ol><li>If <var>module</var>.[[EvaluationError]] is <emu-const>empty</emu-const>, return <var>index</var>.</li><li>Otherwise, return ?&nbsp;<var>module</var>.[[EvaluationError]].</li></ol></li><li>If <var>module</var>.[[Status]] is <emu-const>evaluating</emu-const>, return <var>index</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var>.[[Status]] is <emu-const>linked</emu-const>.</li><li>Set <var>module</var>.[[Status]] to <emu-const>evaluating</emu-const>.</li><li>Set <var>module</var>.[[DFSIndex]] to <var>index</var>.</li><li>Set <var>module</var>.[[DFSAncestorIndex]] to <var>index</var>.</li><li>Set <var>module</var>.[[PendingAsyncDependencies]] to 0.</li><li>Set <var>index</var> to <var>index</var> + 1.</li><li>Append <var>module</var> to <var>stack</var>.</li><li><del>For each String <var>required</var> of <var>module</var>.[[RequestedModules]], do</del></li><li><ins>For each <emu-xref href="#modulerequest-record" id="_ref_85"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref> <var>required</var> of <var>module</var>.[[RequestedModules]], do</ins><ol><li>Let <var>requiredModule</var> be <emu-xref aoid="GetImportedModule"><a href="https://tc39.es/ecma262/#sec-GetImportedModule">GetImportedModule</a></emu-xref>(<var>module</var>, <var>required</var><ins>.[[Specifier]]</ins>).</li><li><ins>If <var>requiredModule</var>.[[Phase]] is <emu-const>evaluation</emu-const>, then</ins><ol><li>Set <var>index</var> to ?&nbsp;<emu-xref aoid="InnerModuleEvaluation" id="_ref_86"><a href="#sec-innermoduleevaluation">InnerModuleEvaluation</a></emu-xref>(<var>requiredModule</var>, <var>stack</var>, <var>index</var>).</li><li>If <var>requiredModule</var> is a <emu-xref href="#cyclic-module-record" id="_ref_87"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>, then<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>requiredModule</var>.[[Status]] is one of <emu-const>evaluating</emu-const>, <emu-const>evaluating-async</emu-const>, or <emu-const>evaluated</emu-const>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>requiredModule</var>.[[Status]] is <emu-const>evaluating</emu-const> if and only if <var>stack</var> contains <var>requiredModule</var>.</li><li>If <var>requiredModule</var>.[[Status]] is <emu-const>evaluating</emu-const>, then<ol><li>Set <var>module</var>.[[DFSAncestorIndex]] to <emu-xref aoid="min"><a href="https://tc39.es/ecma262/#eqn-min">min</a></emu-xref>(<var>module</var>.[[DFSAncestorIndex]], <var>requiredModule</var>.[[DFSAncestorIndex]]).</li></ol></li><li>Else,<ol><li>Set <var>requiredModule</var> to <var>requiredModule</var>.[[CycleRoot]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>requiredModule</var>.[[Status]] is either <emu-const>evaluating-async</emu-const> or <emu-const>evaluated</emu-const>.</li><li>If <var>requiredModule</var>.[[EvaluationError]] is not <emu-const>empty</emu-const>, return ?&nbsp;<var>requiredModule</var>.[[EvaluationError]].</li></ol></li><li>If <var>requiredModule</var>.[[AsyncEvaluation]] is <emu-val>true</emu-val>, then<ol><li>Set <var>module</var>.[[PendingAsyncDependencies]] to <var>module</var>.[[PendingAsyncDependencies]] + 1.</li><li>Append <var>module</var> to <var>requiredModule</var>.[[AsyncParentModules]].</li></ol></li></ol></li></ol></li></ol></li><li>If <var>module</var>.[[PendingAsyncDependencies]] &gt; 0 or <var>module</var>.[[HasTLA]] is <emu-val>true</emu-val>, then<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var>.[[AsyncEvaluation]] is <emu-val>false</emu-val> and was never previously set to <emu-val>true</emu-val>.</li><li>Set <var>module</var>.[[AsyncEvaluation]] to <emu-val>true</emu-val>.</li><li>NOTE: The order in which module records have their [[AsyncEvaluation]] fields transition to <emu-val>true</emu-val> is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"><a href="https://tc39.es/ecma262/#sec-async-module-execution-fulfilled">16.2.1.5.3.4</a></emu-xref>.)</li><li>If <var>module</var>.[[PendingAsyncDependencies]] = 0, perform <emu-xref aoid="ExecuteAsyncModule"><a href="https://tc39.es/ecma262/#sec-execute-async-module">ExecuteAsyncModule</a></emu-xref>(<var>module</var>).</li></ol></li><li>Else,<ol><li>Perform ?&nbsp;<var>module</var>.ExecuteModule().</li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var> occurs exactly once in <var>stack</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var>.[[DFSAncestorIndex]] ≤ <var>module</var>.[[DFSIndex]].</li><li>If <var>module</var>.[[DFSAncestorIndex]] = <var>module</var>.[[DFSIndex]], then<ol><li>Let <var>done</var> be <emu-val>false</emu-val>.</li><li>Repeat, while <var>done</var> is <emu-val>false</emu-val>,<ol><li>Let <var>requiredModule</var> be the last element of <var>stack</var>.</li><li>Remove the last element of <var>stack</var>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>requiredModule</var> is a <emu-xref href="#cyclic-module-record" id="_ref_88"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>.</li><li>If <var>requiredModule</var>.[[AsyncEvaluation]] is <emu-val>false</emu-val>, set <var>requiredModule</var>.[[Status]] to <emu-const>evaluated</emu-const>.</li><li>Otherwise, set <var>requiredModule</var>.[[Status]] to <emu-const>evaluating-async</emu-const>.</li><li>If <var>requiredModule</var> and <var>module</var> are the same <emu-xref href="#sec-abstract-module-records" id="_ref_89"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>, set <var>done</var> to <emu-val>true</emu-val>.</li><li>Set <var>requiredModule</var>.[[CycleRoot]] to <var>module</var>.</li></ol></li></ol></li><li>Return <var>index</var>.</li></ol></emu-alg>
           </emu-clause>
-        </emu-clause>
-        <emu-clause id="sec-getmodulesource" type="concrete method">
-          <h1><span class="secnum">16.1.1.5.4</span> <ins>GetModuleSource ( )</ins></h1>
-          <p>The GetModuleSource concrete method of a <emu-xref href="#cyclic-module-record" id="_ref_87"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> <var>module</var> takes no arguments and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> an Object or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>.</p>
-              <p><emu-xref href="#cyclic-module-record" id="_ref_88"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref> provides a default GetModuleSource implementation with an <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref> to provide a standard reference error that a source phase import is not available.</p>
-            
-          <p>It performs the following steps when called:</p>
-          <emu-alg><ol><li>Let <var>error</var> be a newly created <emu-val>ReferenceError</emu-val> object.</li><li>Return <emu-xref aoid="ThrowCompletion"><a href="https://tc39.es/ecma262/#sec-throwcompletion">ThrowCompletion</a></emu-xref>(<var>error</var>).</li></ol></emu-alg>
         </emu-clause>
       </emu-clause>
 
       <emu-clause id="sec-source-text-module-records">
         <h1><span class="secnum">16.1.1.6</span> Source Text Module Records</h1>
 
+        <emu-clause id="sec-source-text-module-record-getmodulesource" type="concrete method">
+          <h1><span class="secnum">16.1.1.6.1</span> <ins>GetModuleSource ( )</ins></h1>
+          <p>The GetModuleSource concrete method of a <emu-xref href="#sourctextmodule-record"><a href="https://tc39.es/ecma262/#sourctextmodule-record">Source Text Module Record</a></emu-xref> <var>module</var> takes no arguments and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> an Object or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>.</p>
+              <p><emu-xref href="#sourctextmodule-record"><a href="https://tc39.es/ecma262/#sourctextmodule-record">Source Text Module Record</a></emu-xref> provides a GetModuleSource implementation that always returns an <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">abrupt completion</a></emu-xref> indicating that a source phase import is not available.</p>
+            
+          <p>It performs the following steps when called:</p>
+          <emu-alg><ol><li>Throw a <emu-val>ReferenceError</emu-val> exception.</li></ol></emu-alg>
+        </emu-clause>
+
         <emu-clause id="sec-source-text-module-record-initialize-environment" type="concrete method">
-          <h1><span class="secnum">16.1.1.6.1</span> InitializeEnvironment ( )</h1>
+          <h1><span class="secnum">16.1.1.6.2</span> InitializeEnvironment ( )</h1>
           <p>The InitializeEnvironment concrete method of a <emu-xref href="#sourctextmodule-record"><a href="https://tc39.es/ecma262/#sourctextmodule-record">Source Text Module Record</a></emu-xref> <var>module</var> takes no arguments and returns either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> <emu-const>unused</emu-const> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>. It performs the following steps when called:</p>
 
-          <emu-alg><ol><li>For each <emu-xref href="#exportentry-record"><a href="https://tc39.es/ecma262/#exportentry-record">ExportEntry Record</a></emu-xref> <var>e</var> of <var>module</var>.[[IndirectExportEntries]], do<ol><li>Let <var>resolution</var> be <var>module</var>.ResolveExport(<var>e</var>.[[ExportName]]).</li><li>If <var>resolution</var> is either <emu-val>null</emu-val> or <emu-const>ambiguous</emu-const>, throw a <emu-val>SyntaxError</emu-val> exception.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>resolution</var> is a <emu-xref href="#resolvedbinding-record" id="_ref_89"><a href="#resolvedbinding-record">ResolvedBinding Record</a></emu-xref>.</li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: All named exports from <var>module</var> are resolvable.</li><li>Let <var>realm</var> be <var>module</var>.[[Realm]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>realm</var> is not <emu-val>undefined</emu-val>.</li><li>Let <var>env</var> be <emu-xref aoid="NewModuleEnvironment"><a href="https://tc39.es/ecma262/#sec-newmoduleenvironment">NewModuleEnvironment</a></emu-xref>(<var>realm</var>.[[GlobalEnv]]).</li><li>Set <var>module</var>.[[Environment]] to <var>env</var>.</li><li>For each <emu-xref href="#importentry-record" id="_ref_90"><a href="#importentry-record">ImportEntry Record</a></emu-xref> <var>in</var> of <var>module</var>.[[ImportEntries]], do<ol><li>Let <var>importedModule</var> be <emu-xref aoid="GetImportedModule"><a href="https://tc39.es/ecma262/#sec-GetImportedModule">GetImportedModule</a></emu-xref>(<var>module</var>, <var>in</var>.[[ModuleRequest]]).</li><li>If <var>in</var>.[[ImportName]] is <emu-const>namespace-object</emu-const>, then<ol><li>Let <var>namespace</var> be <emu-xref aoid="GetModuleNamespace"><a href="https://tc39.es/ecma262/#sec-getmodulenamespace">GetModuleNamespace</a></emu-xref>(<var>importedModule</var>).</li><li>Perform !&nbsp;<var>env</var>.CreateImmutableBinding(<var>in</var>.[[LocalName]], <emu-val>true</emu-val>).</li><li>Perform !&nbsp;<var>env</var>.InitializeBinding(<var>in</var>.[[LocalName]], <var>namespace</var>).</li></ol></li><li><ins>Else if <var>in</var>.[[ImportName]] is <emu-const>source</emu-const>, then</ins><ol><li><ins>Let <var>moduleSourceObject</var> be ?&nbsp;<var>importedModule</var>.GetModuleSource().</ins></li><li><ins>Perform !&nbsp;<var>env</var>.CreateImmutableBinding(<var>in</var>.[[LocalName]], <emu-val>true</emu-val>).</ins></li><li><ins>Perform !&nbsp;<var>env</var>.InitializeBinding(<var>in</var>.[[LocalName]], <var>moduleSourceObject</var>).</ins></li></ol></li><li>Else,<ol><li>Let <var>resolution</var> be <var>importedModule</var>.ResolveExport(<var>in</var>.[[ImportName]]).</li><li>If <var>resolution</var> is either <emu-val>null</emu-val> or <emu-const>ambiguous</emu-const>, throw a <emu-val>SyntaxError</emu-val> exception.</li><li>If <var>resolution</var>.[[BindingName]] is <emu-const>namespace</emu-const>, then<ol><li>Let <var>namespace</var> be <emu-xref aoid="GetModuleNamespace"><a href="https://tc39.es/ecma262/#sec-getmodulenamespace">GetModuleNamespace</a></emu-xref>(<var>resolution</var>.[[Module]]).</li><li>Perform !&nbsp;<var>env</var>.CreateImmutableBinding(<var>in</var>.[[LocalName]], <emu-val>true</emu-val>).</li><li>Perform !&nbsp;<var>env</var>.InitializeBinding(<var>in</var>.[[LocalName]], <var>namespace</var>).</li></ol></li><li>Else,<ol><li>Perform <var>env</var>.CreateImportBinding(<var>in</var>.[[LocalName]], <var>resolution</var>.[[Module]], <var>resolution</var>.[[BindingName]]).</li></ol></li></ol></li></ol></li><li>Let <var>moduleContext</var> be a new <emu-xref href="#ecmascript-code-execution-context"><a href="https://tc39.es/ecma262/#ecmascript-code-execution-context">ECMAScript code execution context</a></emu-xref>.</li><li>Set the Function of <var>moduleContext</var> to <emu-val>null</emu-val>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var>.[[Realm]] is not <emu-val>undefined</emu-val>.</li><li>Set the <emu-xref href="#realm"><a href="https://tc39.es/ecma262/#realm">Realm</a></emu-xref> of <var>moduleContext</var> to <var>module</var>.[[Realm]].</li><li>Set the ScriptOrModule of <var>moduleContext</var> to <var>module</var>.</li><li>Set the VariableEnvironment of <var>moduleContext</var> to <var>module</var>.[[Environment]].</li><li>Set the LexicalEnvironment of <var>moduleContext</var> to <var>module</var>.[[Environment]].</li><li>Set the PrivateEnvironment of <var>moduleContext</var> to <emu-val>null</emu-val>.</li><li>Set <var>module</var>.[[Context]] to <var>moduleContext</var>.</li><li>Push <var>moduleContext</var> onto the <emu-xref href="#execution-context-stack"><a href="https://tc39.es/ecma262/#execution-context-stack">execution context stack</a></emu-xref>; <var>moduleContext</var> is now the <emu-xref href="#running-execution-context"><a href="https://tc39.es/ecma262/#running-execution-context">running execution context</a></emu-xref>.</li><li>Let <var>code</var> be <var>module</var>.[[ECMAScriptCode]].</li><li>Let <var>varDeclarations</var> be the <emu-xref aoid="VarScopedDeclarations"><a href="https://tc39.es/ecma262/#sec-static-semantics-varscopeddeclarations">VarScopedDeclarations</a></emu-xref> of <var>code</var>.</li><li>Let <var>declaredVarNames</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>For each element <var>d</var> of <var>varDeclarations</var>, do<ol><li>For each element <var>dn</var> of the <emu-xref aoid="BoundNames"><a href="https://tc39.es/ecma262/#sec-static-semantics-boundnames">BoundNames</a></emu-xref> of <var>d</var>, do<ol><li>If <var>declaredVarNames</var> does not contain <var>dn</var>, then<ol><li>Perform !&nbsp;<var>env</var>.CreateMutableBinding(<var>dn</var>, <emu-val>false</emu-val>).</li><li>Perform !&nbsp;<var>env</var>.InitializeBinding(<var>dn</var>, <emu-val>undefined</emu-val>).</li><li>Append <var>dn</var> to <var>declaredVarNames</var>.</li></ol></li></ol></li></ol></li><li>Let <var>lexDeclarations</var> be the <emu-xref aoid="LexicallyScopedDeclarations"><a href="https://tc39.es/ecma262/#sec-static-semantics-lexicallyscopeddeclarations">LexicallyScopedDeclarations</a></emu-xref> of <var>code</var>.</li><li>Let <var>privateEnv</var> be <emu-val>null</emu-val>.</li><li>For each element <var>d</var> of <var>lexDeclarations</var>, do<ol><li>For each element <var>dn</var> of the <emu-xref aoid="BoundNames"><a href="https://tc39.es/ecma262/#sec-static-semantics-boundnames">BoundNames</a></emu-xref> of <var>d</var>, do<ol><li>If <emu-xref aoid="IsConstantDeclaration"><a href="https://tc39.es/ecma262/#sec-static-semantics-isconstantdeclaration">IsConstantDeclaration</a></emu-xref> of <var>d</var> is <emu-val>true</emu-val>, then<ol><li>Perform !&nbsp;<var>env</var>.CreateImmutableBinding(<var>dn</var>, <emu-val>true</emu-val>).</li></ol></li><li>Else,<ol><li>Perform !&nbsp;<var>env</var>.CreateMutableBinding(<var>dn</var>, <emu-val>false</emu-val>).</li></ol></li><li>If <var>d</var> is either a <emu-nt><a href="https://tc39.es/ecma262/#prod-FunctionDeclaration">FunctionDeclaration</a></emu-nt>, a <emu-nt><a href="https://tc39.es/ecma262/#prod-GeneratorDeclaration">GeneratorDeclaration</a></emu-nt>, an <emu-nt><a href="https://tc39.es/ecma262/#prod-AsyncFunctionDeclaration">AsyncFunctionDeclaration</a></emu-nt>, or an <emu-nt><a href="https://tc39.es/ecma262/#prod-AsyncGeneratorDeclaration">AsyncGeneratorDeclaration</a></emu-nt>, then<ol><li>Let <var>fo</var> be <emu-xref aoid="InstantiateFunctionObject"><a href="https://tc39.es/ecma262/#sec-runtime-semantics-instantiatefunctionobject">InstantiateFunctionObject</a></emu-xref> of <var>d</var> with arguments <var>env</var> and <var>privateEnv</var>.</li><li>Perform !&nbsp;<var>env</var>.InitializeBinding(<var>dn</var>, <var>fo</var>).</li></ol></li></ol></li></ol></li><li>Remove <var>moduleContext</var> from the <emu-xref href="#execution-context-stack"><a href="https://tc39.es/ecma262/#execution-context-stack">execution context stack</a></emu-xref>.</li><li>Return <emu-const>unused</emu-const>.</li></ol></emu-alg>
+          <emu-alg><ol><li>For each <emu-xref href="#exportentry-record"><a href="https://tc39.es/ecma262/#exportentry-record">ExportEntry Record</a></emu-xref> <var>e</var> of <var>module</var>.[[IndirectExportEntries]], do<ol><li>Let <var>resolution</var> be <var>module</var>.ResolveExport(<var>e</var>.[[ExportName]]).</li><li>If <var>resolution</var> is either <emu-val>null</emu-val> or <emu-const>ambiguous</emu-const>, throw a <emu-val>SyntaxError</emu-val> exception.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>resolution</var> is a <emu-xref href="#resolvedbinding-record" id="_ref_90"><a href="#resolvedbinding-record">ResolvedBinding Record</a></emu-xref>.</li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: All named exports from <var>module</var> are resolvable.</li><li>Let <var>realm</var> be <var>module</var>.[[Realm]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>realm</var> is not <emu-val>undefined</emu-val>.</li><li>Let <var>env</var> be <emu-xref aoid="NewModuleEnvironment"><a href="https://tc39.es/ecma262/#sec-newmoduleenvironment">NewModuleEnvironment</a></emu-xref>(<var>realm</var>.[[GlobalEnv]]).</li><li>Set <var>module</var>.[[Environment]] to <var>env</var>.</li><li>For each <emu-xref href="#importentry-record" id="_ref_91"><a href="#importentry-record">ImportEntry Record</a></emu-xref> <var>in</var> of <var>module</var>.[[ImportEntries]], do<ol><li>Let <var>importedModule</var> be <emu-xref aoid="GetImportedModule"><a href="https://tc39.es/ecma262/#sec-GetImportedModule">GetImportedModule</a></emu-xref>(<var>module</var>, <var>in</var>.[[ModuleRequest]]).</li><li>If <var>in</var>.[[ImportName]] is <emu-const>namespace-object</emu-const>, then<ol><li>Let <var>namespace</var> be <emu-xref aoid="GetModuleNamespace"><a href="https://tc39.es/ecma262/#sec-getmodulenamespace">GetModuleNamespace</a></emu-xref>(<var>importedModule</var>).</li><li>Perform !&nbsp;<var>env</var>.CreateImmutableBinding(<var>in</var>.[[LocalName]], <emu-val>true</emu-val>).</li><li>Perform !&nbsp;<var>env</var>.InitializeBinding(<var>in</var>.[[LocalName]], <var>namespace</var>).</li></ol></li><li><ins>Else if <var>in</var>.[[ImportName]] is <emu-const>source</emu-const>, then</ins><ol><li><ins>Let <var>moduleSourceObject</var> be ?&nbsp;<var>importedModule</var>.GetModuleSource().</ins></li><li><ins>Perform !&nbsp;<var>env</var>.CreateImmutableBinding(<var>in</var>.[[LocalName]], <emu-val>true</emu-val>).</ins></li><li><ins>Perform !&nbsp;<var>env</var>.InitializeBinding(<var>in</var>.[[LocalName]], <var>moduleSourceObject</var>).</ins></li></ol></li><li>Else,<ol><li>Let <var>resolution</var> be <var>importedModule</var>.ResolveExport(<var>in</var>.[[ImportName]]).</li><li>If <var>resolution</var> is either <emu-val>null</emu-val> or <emu-const>ambiguous</emu-const>, throw a <emu-val>SyntaxError</emu-val> exception.</li><li>If <var>resolution</var>.[[BindingName]] is <emu-const>namespace</emu-const>, then<ol><li>Let <var>namespace</var> be <emu-xref aoid="GetModuleNamespace"><a href="https://tc39.es/ecma262/#sec-getmodulenamespace">GetModuleNamespace</a></emu-xref>(<var>resolution</var>.[[Module]]).</li><li>Perform !&nbsp;<var>env</var>.CreateImmutableBinding(<var>in</var>.[[LocalName]], <emu-val>true</emu-val>).</li><li>Perform !&nbsp;<var>env</var>.InitializeBinding(<var>in</var>.[[LocalName]], <var>namespace</var>).</li></ol></li><li>Else,<ol><li>Perform <var>env</var>.CreateImportBinding(<var>in</var>.[[LocalName]], <var>resolution</var>.[[Module]], <var>resolution</var>.[[BindingName]]).</li></ol></li></ol></li></ol></li><li>Let <var>moduleContext</var> be a new <emu-xref href="#ecmascript-code-execution-context"><a href="https://tc39.es/ecma262/#ecmascript-code-execution-context">ECMAScript code execution context</a></emu-xref>.</li><li>Set the Function of <var>moduleContext</var> to <emu-val>null</emu-val>.</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>module</var>.[[Realm]] is not <emu-val>undefined</emu-val>.</li><li>Set the <emu-xref href="#realm"><a href="https://tc39.es/ecma262/#realm">Realm</a></emu-xref> of <var>moduleContext</var> to <var>module</var>.[[Realm]].</li><li>Set the ScriptOrModule of <var>moduleContext</var> to <var>module</var>.</li><li>Set the VariableEnvironment of <var>moduleContext</var> to <var>module</var>.[[Environment]].</li><li>Set the LexicalEnvironment of <var>moduleContext</var> to <var>module</var>.[[Environment]].</li><li>Set the PrivateEnvironment of <var>moduleContext</var> to <emu-val>null</emu-val>.</li><li>Set <var>module</var>.[[Context]] to <var>moduleContext</var>.</li><li>Push <var>moduleContext</var> onto the <emu-xref href="#execution-context-stack"><a href="https://tc39.es/ecma262/#execution-context-stack">execution context stack</a></emu-xref>; <var>moduleContext</var> is now the <emu-xref href="#running-execution-context"><a href="https://tc39.es/ecma262/#running-execution-context">running execution context</a></emu-xref>.</li><li>Let <var>code</var> be <var>module</var>.[[ECMAScriptCode]].</li><li>Let <var>varDeclarations</var> be the <emu-xref aoid="VarScopedDeclarations"><a href="https://tc39.es/ecma262/#sec-static-semantics-varscopeddeclarations">VarScopedDeclarations</a></emu-xref> of <var>code</var>.</li><li>Let <var>declaredVarNames</var> be a new empty <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref>.</li><li>For each element <var>d</var> of <var>varDeclarations</var>, do<ol><li>For each element <var>dn</var> of the <emu-xref aoid="BoundNames"><a href="https://tc39.es/ecma262/#sec-static-semantics-boundnames">BoundNames</a></emu-xref> of <var>d</var>, do<ol><li>If <var>declaredVarNames</var> does not contain <var>dn</var>, then<ol><li>Perform !&nbsp;<var>env</var>.CreateMutableBinding(<var>dn</var>, <emu-val>false</emu-val>).</li><li>Perform !&nbsp;<var>env</var>.InitializeBinding(<var>dn</var>, <emu-val>undefined</emu-val>).</li><li>Append <var>dn</var> to <var>declaredVarNames</var>.</li></ol></li></ol></li></ol></li><li>Let <var>lexDeclarations</var> be the <emu-xref aoid="LexicallyScopedDeclarations"><a href="https://tc39.es/ecma262/#sec-static-semantics-lexicallyscopeddeclarations">LexicallyScopedDeclarations</a></emu-xref> of <var>code</var>.</li><li>Let <var>privateEnv</var> be <emu-val>null</emu-val>.</li><li>For each element <var>d</var> of <var>lexDeclarations</var>, do<ol><li>For each element <var>dn</var> of the <emu-xref aoid="BoundNames"><a href="https://tc39.es/ecma262/#sec-static-semantics-boundnames">BoundNames</a></emu-xref> of <var>d</var>, do<ol><li>If <emu-xref aoid="IsConstantDeclaration"><a href="https://tc39.es/ecma262/#sec-static-semantics-isconstantdeclaration">IsConstantDeclaration</a></emu-xref> of <var>d</var> is <emu-val>true</emu-val>, then<ol><li>Perform !&nbsp;<var>env</var>.CreateImmutableBinding(<var>dn</var>, <emu-val>true</emu-val>).</li></ol></li><li>Else,<ol><li>Perform !&nbsp;<var>env</var>.CreateMutableBinding(<var>dn</var>, <emu-val>false</emu-val>).</li></ol></li><li>If <var>d</var> is either a <emu-nt><a href="https://tc39.es/ecma262/#prod-FunctionDeclaration">FunctionDeclaration</a></emu-nt>, a <emu-nt><a href="https://tc39.es/ecma262/#prod-GeneratorDeclaration">GeneratorDeclaration</a></emu-nt>, an <emu-nt><a href="https://tc39.es/ecma262/#prod-AsyncFunctionDeclaration">AsyncFunctionDeclaration</a></emu-nt>, or an <emu-nt><a href="https://tc39.es/ecma262/#prod-AsyncGeneratorDeclaration">AsyncGeneratorDeclaration</a></emu-nt>, then<ol><li>Let <var>fo</var> be <emu-xref aoid="InstantiateFunctionObject"><a href="https://tc39.es/ecma262/#sec-runtime-semantics-instantiatefunctionobject">InstantiateFunctionObject</a></emu-xref> of <var>d</var> with arguments <var>env</var> and <var>privateEnv</var>.</li><li>Perform !&nbsp;<var>env</var>.InitializeBinding(<var>dn</var>, <var>fo</var>).</li></ol></li></ol></li></ol></li><li>Remove <var>moduleContext</var> from the <emu-xref href="#execution-context-stack"><a href="https://tc39.es/ecma262/#execution-context-stack">execution context stack</a></emu-xref>.</li><li>Return <emu-const>unused</emu-const>.</li></ol></emu-alg>
         </emu-clause>
       </emu-clause>
-      <p>An <dfn id="importentry-record" variants="ImportEntry Records">ImportEntry Record</dfn> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> that digests information about a single declarative import. Each <emu-xref href="#importentry-record" id="_ref_91"><a href="#importentry-record">ImportEntry Record</a></emu-xref> has the fields defined in <emu-xref href="#table-importentry-record-fields" id="_ref_6"><a href="#table-importentry-record-fields">Table 5</a></emu-xref>:</p>
-      <emu-table id="table-importentry-record-fields" caption="ImportEntry Record Fields" oldids="table-39"><figure><figcaption>Table 5: <emu-xref href="#importentry-record" id="_ref_92"><a href="#importentry-record">ImportEntry Record</a></emu-xref> Fields</figcaption><span id="table-39"></span>
+      <p>An <dfn id="importentry-record" variants="ImportEntry Records">ImportEntry Record</dfn> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> that digests information about a single declarative import. Each <emu-xref href="#importentry-record" id="_ref_92"><a href="#importentry-record">ImportEntry Record</a></emu-xref> has the fields defined in <emu-xref href="#table-importentry-record-fields" id="_ref_8"><a href="#table-importentry-record-fields">Table 6</a></emu-xref>:</p>
+      <emu-table id="table-importentry-record-fields" caption="ImportEntry Record Fields" oldids="table-39"><figure><figcaption>Table 6: <emu-xref href="#importentry-record" id="_ref_93"><a href="#importentry-record">ImportEntry Record</a></emu-xref> Fields</figcaption><span id="table-39"></span>
         <table>
           <tbody><tr>
             <th>
@@ -3110,7 +3899,7 @@ li.menu-search-result-term:before {
               a String
             </td>
             <td>
-              String value of the <emu-nt id="_ref_133"><a href="#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt> of the <emu-nt id="_ref_134"><a href="#prod-ImportDeclaration">ImportDeclaration</a></emu-nt>.
+              String value of the <emu-nt id="_ref_130"><a href="#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt> of the <emu-nt id="_ref_131"><a href="#prod-ImportDeclaration">ImportDeclaration</a></emu-nt>.
             </td>
           </tr>
           <tr>
@@ -3121,7 +3910,7 @@ li.menu-search-result-term:before {
               a String <del>or <emu-const>namespace-object</emu-const></del><ins>, <emu-const>namespace-object</emu-const> or <emu-const>source</emu-const></ins>
             </td>
             <td>
-              The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value <emu-const>namespace-object</emu-const> indicates that the import request is for the target module's namespace object. <ins>The value <emu-const>source</emu-const> represents an import of the import phase representation at that phase name.</ins>
+              The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value <emu-const>namespace-object</emu-const> indicates that the import request is for the target module's namespace object. <ins>The value <emu-const>source</emu-const> represents an import at the source phase.</ins>
             </td>
           </tr>
           <tr>
@@ -3138,8 +3927,8 @@ li.menu-search-result-term:before {
         </tbody></table>
       </figure></emu-table>
       <emu-note class="module-overflow-note"><span class="note">Note</span><div class="note-contents">
-        <p><emu-xref href="#table-import-forms-mapping-to-importentry-records" id="_ref_7"><a href="#table-import-forms-mapping-to-importentry-records">Table 6</a></emu-xref> gives examples of ImportEntry records fields used to represent the syntactic import forms:</p>
-        <emu-table id="table-import-forms-mapping-to-importentry-records" caption="Import Forms Mappings to ImportEntry Records" informative="" oldids="table-40"><figure><figcaption>Table 6 (Informative): Import Forms Mappings to <emu-xref href="#importentry-record" id="_ref_93"><a href="#importentry-record">ImportEntry Records</a></emu-xref></figcaption><span id="table-40"></span>
+        <p><emu-xref href="#table-import-forms-mapping-to-importentry-records" id="_ref_9"><a href="#table-import-forms-mapping-to-importentry-records">Table 7</a></emu-xref> gives examples of ImportEntry records fields used to represent the syntactic import forms:</p>
+        <emu-table id="table-import-forms-mapping-to-importentry-records" caption="Import Forms Mappings to ImportEntry Records" informative="" oldids="table-40"><figure><figcaption>Table 7 (Informative): Import Forms Mappings to <emu-xref href="#importentry-record" id="_ref_94"><a href="#importentry-record">ImportEntry Records</a></emu-xref></figcaption><span id="table-40"></span>
           <table>
             <tbody><tr>
               <th>
@@ -3216,7 +4005,7 @@ li.menu-search-result-term:before {
                 <code>import "mod";</code>
               </td>
               <td colspan="3">
-                An <emu-xref href="#importentry-record" id="_ref_94"><a href="#importentry-record">ImportEntry Record</a></emu-xref> is not created.
+                An <emu-xref href="#importentry-record" id="_ref_95"><a href="#importentry-record">ImportEntry Record</a></emu-xref> is not created.
               </td>
             </tr>
           </tbody></table>
@@ -3225,33 +4014,33 @@ li.menu-search-result-term:before {
 
       <emu-clause id="sec-HostLoadImportedModule" type="host-defined abstract operation" aoid="HostLoadImportedModule">
         <h1><span class="secnum">16.1.1.7</span> HostLoadImportedModule ( <var>referrer</var>, <del><var>specifier</var></del>, <ins><var>moduleRequest</var></ins>, <var>hostDefined</var>, <var>payload</var> )</h1>
-        <p>The <emu-xref href="#host-defined"><a href="https://tc39.es/ecma262/#host-defined">host-defined</a></emu-xref> abstract operation HostLoadImportedModule takes arguments <var>referrer</var> (a <emu-xref href="#script-record"><a href="https://tc39.es/ecma262/#script-record">Script Record</a></emu-xref>, a <emu-xref href="#cyclic-module-record" id="_ref_95"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>, or a <emu-xref href="#realm-record"><a href="https://tc39.es/ecma262/#realm-record">Realm Record</a></emu-xref>), <del><var>specifier</var> (a String)</del>, <ins><var>moduleRequest</var> (a <emu-xref href="#modulerequest-record" id="_ref_96"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref>)</ins>, <var>hostDefined</var> (anything), and <var>payload</var> (a <emu-xref href="#graphloadingstate-record"><a href="https://tc39.es/ecma262/#graphloadingstate-record">GraphLoadingState Record</a></emu-xref> or a <emu-xref href="#sec-promisecapability-records"><a href="https://tc39.es/ecma262/#sec-promisecapability-records">PromiseCapability Record</a></emu-xref>) and returns <emu-const>unused</emu-const>.</p>
+        <p>The <emu-xref href="#host-defined"><a href="https://tc39.es/ecma262/#host-defined">host-defined</a></emu-xref> abstract operation HostLoadImportedModule takes arguments <var>referrer</var> (a <emu-xref href="#script-record"><a href="https://tc39.es/ecma262/#script-record">Script Record</a></emu-xref>, a <emu-xref href="#cyclic-module-record" id="_ref_96"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>, or a <emu-xref href="#realm-record"><a href="https://tc39.es/ecma262/#realm-record">Realm Record</a></emu-xref>), <del><var>specifier</var> (a String)</del>, <ins><var>moduleRequest</var> (a <emu-xref href="#modulerequest-record" id="_ref_97"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref>)</ins>, <var>hostDefined</var> (anything), and <var>payload</var> (a <emu-xref href="#graphloadingstate-record"><a href="https://tc39.es/ecma262/#graphloadingstate-record">GraphLoadingState Record</a></emu-xref> or a <emu-xref href="#sec-promisecapability-records"><a href="https://tc39.es/ecma262/#sec-promisecapability-records">PromiseCapability Record</a></emu-xref>) and returns <emu-const>unused</emu-const>.</p>
 
         <emu-note id="note-HostLoadImportedModule-referrer-Realm-Record"><span class="note"><a href="#note-HostLoadImportedModule-referrer-Realm-Record">Note 1</a></span><div class="note-contents">
           <p>An example of when <var>referrer</var> can be a <emu-xref href="#realm-record"><a href="https://tc39.es/ecma262/#realm-record">Realm Record</a></emu-xref> is in a web browser <emu-xref href="#host"><a href="https://tc39.es/ecma262/#host">host</a></emu-xref>. There, if a user clicks on a control given by</p>
 
           <pre><code class="html hljs"><span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"button"</span> <span class="hljs-attr">onclick</span>=<span class="hljs-string">"import('./foo.mjs')"</span>&gt;</span>Click me<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span></code></pre>
 
-          <p>there will be no <emu-xref href="#job-activescriptormodule"><a href="https://tc39.es/ecma262/#job-activescriptormodule">active script or module</a></emu-xref> at the time the <emu-xref href="#sec-import-calls" id="_ref_8"><a href="#sec-import-calls"><code>import()</code></a></emu-xref> expression runs. More generally, this can happen in any situation where the <emu-xref href="#host"><a href="https://tc39.es/ecma262/#host">host</a></emu-xref> pushes <emu-xref href="#sec-execution-contexts"><a href="https://tc39.es/ecma262/#sec-execution-contexts">execution contexts</a></emu-xref> with <emu-val>null</emu-val> ScriptOrModule components onto the <emu-xref href="#execution-context-stack"><a href="https://tc39.es/ecma262/#execution-context-stack">execution context stack</a></emu-xref>.</p>
+          <p>there will be no <emu-xref href="#job-activescriptormodule"><a href="https://tc39.es/ecma262/#job-activescriptormodule">active script or module</a></emu-xref> at the time the <emu-xref href="#sec-import-calls" id="_ref_10"><a href="#sec-import-calls"><code>import()</code></a></emu-xref> expression runs. More generally, this can happen in any situation where the <emu-xref href="#host"><a href="https://tc39.es/ecma262/#host">host</a></emu-xref> pushes <emu-xref href="#sec-execution-contexts"><a href="https://tc39.es/ecma262/#sec-execution-contexts">execution contexts</a></emu-xref> with <emu-val>null</emu-val> ScriptOrModule components onto the <emu-xref href="#execution-context-stack"><a href="https://tc39.es/ecma262/#execution-context-stack">execution context stack</a></emu-xref>.</p>
         </div></emu-note>
 
         <p>An implementation of HostLoadImportedModule must conform to the following requirements:</p>
         <ul>
           <li>
-            The <emu-xref href="#host-environment"><a href="https://tc39.es/ecma262/#host-environment">host environment</a></emu-xref> must perform <emu-xref aoid="FinishLoadingImportedModule" id="_ref_97"><a href="#sec-FinishLoadingImportedModule">FinishLoadingImportedModule</a></emu-xref>(<var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var>), where <var>result</var> is either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> the loaded <emu-xref href="#sec-abstract-module-records" id="_ref_98"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>, either synchronously or asynchronously.
+            The <emu-xref href="#host-environment"><a href="https://tc39.es/ecma262/#host-environment">host environment</a></emu-xref> must perform <emu-xref aoid="FinishLoadingImportedModule" id="_ref_98"><a href="#sec-FinishLoadingImportedModule">FinishLoadingImportedModule</a></emu-xref>(<var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var>), where <var>result</var> is either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> the loaded <emu-xref href="#sec-abstract-module-records" id="_ref_99"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>, either synchronously or asynchronously.
           </li>
           <li>
-            If this operation is called multiple times with the same (<var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var>.[[Specifier]]</ins>) pair and it performs <emu-xref aoid="FinishLoadingImportedModule" id="_ref_99"><a href="#sec-FinishLoadingImportedModule">FinishLoadingImportedModule</a></emu-xref>(<var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var>) where <var>result</var> is a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion</a></emu-xref>, then it must perform <emu-xref aoid="FinishLoadingImportedModule" id="_ref_100"><a href="#sec-FinishLoadingImportedModule">FinishLoadingImportedModule</a></emu-xref>(<var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var>) with the same <var>result</var> each time.
+            If this operation is called multiple times with the same (<var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var>.[[Specifier]]</ins>) pair and it performs <emu-xref aoid="FinishLoadingImportedModule" id="_ref_100"><a href="#sec-FinishLoadingImportedModule">FinishLoadingImportedModule</a></emu-xref>(<var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var>) where <var>result</var> is a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion</a></emu-xref>, then it must perform <emu-xref aoid="FinishLoadingImportedModule" id="_ref_101"><a href="#sec-FinishLoadingImportedModule">FinishLoadingImportedModule</a></emu-xref>(<var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var>) with the same <var>result</var> each time.
           </li>
           <li>
             <ins>The completion record returned by this operation must not be affected by <var>moduleRequest</var>.[[Phase]].</ins>
           </li>
           <li>
-            The operation must treat <var>payload</var> as an opaque value to be passed through to <emu-xref aoid="FinishLoadingImportedModule" id="_ref_101"><a href="#sec-FinishLoadingImportedModule">FinishLoadingImportedModule</a></emu-xref>.
+            The operation must treat <var>payload</var> as an opaque value to be passed through to <emu-xref aoid="FinishLoadingImportedModule" id="_ref_102"><a href="#sec-FinishLoadingImportedModule">FinishLoadingImportedModule</a></emu-xref>.
           </li>
         </ul>
 
-        <p>The actual process performed is <emu-xref href="#host-defined"><a href="https://tc39.es/ecma262/#host-defined">host-defined</a></emu-xref>, but typically consists of performing whatever I/O operations are necessary to load the appropriate <emu-xref href="#sec-abstract-module-records" id="_ref_102"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>. Multiple different (<var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var>.[[Specifier]]</ins>) pairs may map to the same <emu-xref href="#sec-abstract-module-records" id="_ref_103"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> instance. The actual mapping semantics is <emu-xref href="#host-defined"><a href="https://tc39.es/ecma262/#host-defined">host-defined</a></emu-xref> but typically a normalization process is applied to <var>specifier</var> as part of the mapping process. A typical normalization process would include actions such as expansion of relative and abbreviated path specifiers.</p>
+        <p>The actual process performed is <emu-xref href="#host-defined"><a href="https://tc39.es/ecma262/#host-defined">host-defined</a></emu-xref>, but typically consists of performing whatever I/O operations are necessary to load the appropriate <emu-xref href="#sec-abstract-module-records" id="_ref_103"><a href="#sec-abstract-module-records">Module Record</a></emu-xref>. Multiple different (<var>referrer</var>, <del><var>specifier</var></del><ins><var>moduleRequest</var>.[[Specifier]]</ins>) pairs may map to the same <emu-xref href="#sec-abstract-module-records" id="_ref_104"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> instance. The actual mapping semantics is <emu-xref href="#host-defined"><a href="https://tc39.es/ecma262/#host-defined">host-defined</a></emu-xref> but typically a normalization process is applied to <var>specifier</var> as part of the mapping process. A typical normalization process would include actions such as expansion of relative and abbreviated path specifiers.</p>
 
         <emu-note><span class="note">Note 2</span><div class="note-contents">
           <p><ins><emu-xref href="#sec-hosts-and-implementations"><a href="https://tc39.es/ecma262/#sec-hosts-and-implementations">Implementations</a></emu-xref> may provide unobservable module loading optimizations, such as speculative preloading of modules that are likely to be requested next. When doing so, they should consider whether the module is being imported for its <emu-const>source</emu-const> phase, which won't cause calls to the HostLoadImportedModule hook for its transitive dependencies, or for its <emu-const>evaluation</emu-const> phase, which will.</ins></p>
@@ -3260,8 +4049,8 @@ li.menu-search-result-term:before {
 
       <emu-clause id="sec-FinishLoadingImportedModule" type="abstract operation" aoid="FinishLoadingImportedModule">
         <h1><span class="secnum">16.1.1.8</span> FinishLoadingImportedModule ( <var>referrer</var>, <del><var>specifier</var></del>, <ins><var>moduleRequest</var></ins>, <var>payload</var>, <var>result</var> )</h1>
-        <p>The abstract operation FinishLoadingImportedModule takes arguments <var>referrer</var> (a <emu-xref href="#script-record"><a href="https://tc39.es/ecma262/#script-record">Script Record</a></emu-xref>, a <emu-xref href="#cyclic-module-record" id="_ref_104"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>, or a <emu-xref href="#realm-record"><a href="https://tc39.es/ecma262/#realm-record">Realm Record</a></emu-xref>), <del><var>specifier</var> (a String)</del>, <ins><var>moduleRequest</var> (a <emu-xref href="#modulerequest-record" id="_ref_105"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref>)</ins>, <var>payload</var> (a <emu-xref href="#graphloadingstate-record"><a href="https://tc39.es/ecma262/#graphloadingstate-record">GraphLoadingState Record</a></emu-xref> or a <emu-xref href="#sec-promisecapability-records"><a href="https://tc39.es/ecma262/#sec-promisecapability-records">PromiseCapability Record</a></emu-xref>), and <var>result</var> (either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a <emu-xref href="#sec-abstract-module-records" id="_ref_106"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>) and returns <emu-const>unused</emu-const>. It performs the following steps when called:</p>
-        <emu-alg><ol><li>If <var>result</var> is a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion</a></emu-xref>, then<ol><li>If <var>referrer</var>.[[LoadedModules]] contains a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> <var>record</var> such that <var>record</var>.[[Specifier]] is <del><var>specifier</var></del><ins><var>moduleRequest</var>.[[Specifier]]</ins>, then<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>record</var>.[[Module]] is <var>result</var>.[[Value]].</li></ol></li><li>Else, append the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Specifier]]: <del><var>specifier</var></del><ins><var>moduleRequest</var>.[[Specifier]]</ins>, [[Module]]: <var>result</var>.[[Value]] } to <var>referrer</var>.[[LoadedModules]].</li></ol></li><li>If <var>payload</var> is a <emu-xref href="#graphloadingstate-record"><a href="https://tc39.es/ecma262/#graphloadingstate-record">GraphLoadingState Record</a></emu-xref>, then<ol><li>Perform <emu-xref aoid="ContinueModuleLoading" id="_ref_107"><a href="#sec-ContinueModuleLoading">ContinueModuleLoading</a></emu-xref>(<var>payload</var>, <ins><var>moduleRequest</var>.[[Phase]],</ins> <var>result</var>).</li></ol></li><li>Else,<ol><li>Perform <emu-xref aoid="ContinueDynamicImport" id="_ref_108"><a href="#sec-ContinueDynamicImport">ContinueDynamicImport</a></emu-xref>(<var>payload</var>, <ins><var>moduleRequest</var>.[[Phase]],</ins> <var>result</var>).</li></ol></li></ol></emu-alg>
+        <p>The abstract operation FinishLoadingImportedModule takes arguments <var>referrer</var> (a <emu-xref href="#script-record"><a href="https://tc39.es/ecma262/#script-record">Script Record</a></emu-xref>, a <emu-xref href="#cyclic-module-record" id="_ref_105"><a href="#cyclic-module-record">Cyclic Module Record</a></emu-xref>, or a <emu-xref href="#realm-record"><a href="https://tc39.es/ecma262/#realm-record">Realm Record</a></emu-xref>), <del><var>specifier</var> (a String)</del>, <ins><var>moduleRequest</var> (a <emu-xref href="#modulerequest-record" id="_ref_106"><a href="#modulerequest-record">ModuleRequest Record</a></emu-xref>)</ins>, <var>payload</var> (a <emu-xref href="#graphloadingstate-record"><a href="https://tc39.es/ecma262/#graphloadingstate-record">GraphLoadingState Record</a></emu-xref> or a <emu-xref href="#sec-promisecapability-records"><a href="https://tc39.es/ecma262/#sec-promisecapability-records">PromiseCapability Record</a></emu-xref>), and <var>result</var> (either a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion containing</a></emu-xref> a <emu-xref href="#sec-abstract-module-records" id="_ref_107"><a href="#sec-abstract-module-records">Module Record</a></emu-xref> or a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">throw completion</a></emu-xref>) and returns <emu-const>unused</emu-const>. It performs the following steps when called:</p>
+        <emu-alg><ol><li>If <var>result</var> is a <emu-xref href="#sec-completion-record-specification-type"><a href="https://tc39.es/ecma262/#sec-completion-record-specification-type">normal completion</a></emu-xref>, then<ol><li>If <var>referrer</var>.[[LoadedModules]] contains a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> whose [[Specifier]] is <del><var>specifier</var></del><ins><var>moduleRequest</var>.[[Specifier]]</ins>, then<ol><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>record</var>.[[Module]] is <var>result</var>.[[Value]].</li></ol></li><li>Else, append the <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> { [[Specifier]]: <del><var>specifier</var></del><ins><var>moduleRequest</var>.[[Specifier]]</ins>, [[Module]]: <var>result</var>.[[Value]] } to <var>referrer</var>.[[LoadedModules]].</li></ol></li><li>If <var>payload</var> is a <emu-xref href="#graphloadingstate-record"><a href="https://tc39.es/ecma262/#graphloadingstate-record">GraphLoadingState Record</a></emu-xref>, then<ol><li>Perform <emu-xref aoid="ContinueModuleLoading" id="_ref_108"><a href="#sec-ContinueModuleLoading">ContinueModuleLoading</a></emu-xref>(<var>payload</var>, <ins><var>moduleRequest</var>.[[Phase]],</ins> <var>result</var>).</li></ol></li><li>Else,<ol><li>Perform <emu-xref aoid="ContinueDynamicImport" id="_ref_109"><a href="#sec-ContinueDynamicImport">ContinueDynamicImport</a></emu-xref>(<var>payload</var>, <ins><var>moduleRequest</var>.[[Phase]],</ins> <var>result</var>).</li></ol></li></ol></emu-alg>
       </emu-clause>
     </emu-clause>
   </emu-clause>
@@ -3272,54 +4061,54 @@ li.menu-search-result-term:before {
     <emu-grammar type="definition"><emu-production name="ImportDeclaration" id="prod-ImportDeclaration">
     <emu-nt><a href="#prod-ImportDeclaration">ImportDeclaration</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="glhuxxec" id="prod-WzAgO-V_">
         <emu-t>import</emu-t>
-        <emu-nt id="_ref_135"><a href="#prod-ImportClause">ImportClause</a></emu-nt>
-        <emu-nt id="_ref_136"><a href="#prod-FromClause">FromClause</a></emu-nt>
+        <emu-nt id="_ref_132"><a href="#prod-ImportClause">ImportClause</a></emu-nt>
+        <emu-nt id="_ref_133"><a href="#prod-FromClause">FromClause</a></emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs>
     <emu-rhs a="odcuzpbi" id="prod-CDGJVPkq">
         <emu-t>import</emu-t>
-        <emu-nt id="_ref_137"><a href="#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt>
+        <emu-nt id="_ref_134"><a href="#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs>
     <ins><emu-rhs a="dch9dh2n" id="prod-gQ0CVk3C">
         <emu-t>import</emu-t>
         <emu-t>source</emu-t>
-        <emu-nt id="_ref_138"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>
-        <emu-nt id="_ref_139"><a href="#prod-FromClause">FromClause</a></emu-nt>
+        <emu-nt id="_ref_135"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>
+        <emu-nt id="_ref_136"><a href="#prod-FromClause">FromClause</a></emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs></ins>
 </emu-production>
 <emu-production name="ImportClause" id="prod-ImportClause">
     <emu-nt><a href="#prod-ImportClause">ImportClause</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="oi8izote">
-        <emu-nt id="_ref_140"><a href="#prod-ImportedDefaultBinding">ImportedDefaultBinding</a></emu-nt>
+        <emu-nt id="_ref_137"><a href="#prod-ImportedDefaultBinding">ImportedDefaultBinding</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="81tm-dw4">
-        <emu-nt id="_ref_141"><a href="#prod-NameSpaceImport">NameSpaceImport</a></emu-nt>
+        <emu-nt id="_ref_138"><a href="#prod-NameSpaceImport">NameSpaceImport</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="zfagpfvq">
-        <emu-nt id="_ref_142"><a href="#prod-NamedImports">NamedImports</a></emu-nt>
+        <emu-nt id="_ref_139"><a href="#prod-NamedImports">NamedImports</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="y9r1l58g">
-        <emu-nt id="_ref_143"><a href="#prod-ImportedDefaultBinding">ImportedDefaultBinding</a></emu-nt>
+        <emu-nt id="_ref_140"><a href="#prod-ImportedDefaultBinding">ImportedDefaultBinding</a></emu-nt>
         <emu-t>,</emu-t>
-        <emu-nt id="_ref_144"><a href="#prod-NameSpaceImport">NameSpaceImport</a></emu-nt>
+        <emu-nt id="_ref_141"><a href="#prod-NameSpaceImport">NameSpaceImport</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="ih8rgsdx">
-        <emu-nt id="_ref_145"><a href="#prod-ImportedDefaultBinding">ImportedDefaultBinding</a></emu-nt>
+        <emu-nt id="_ref_142"><a href="#prod-ImportedDefaultBinding">ImportedDefaultBinding</a></emu-nt>
         <emu-t>,</emu-t>
-        <emu-nt id="_ref_146"><a href="#prod-NamedImports">NamedImports</a></emu-nt>
+        <emu-nt id="_ref_143"><a href="#prod-NamedImports">NamedImports</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ImportedDefaultBinding" id="prod-ImportedDefaultBinding">
     <emu-nt><a href="#prod-ImportedDefaultBinding">ImportedDefaultBinding</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="vt7awvcp">
-        <emu-nt id="_ref_147"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>
+        <emu-nt id="_ref_144"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="NameSpaceImport" id="prod-NameSpaceImport">
     <emu-nt><a href="#prod-NameSpaceImport">NameSpaceImport</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="t2qf80pb">
         <emu-t>*</emu-t>
         <emu-t>as</emu-t>
-        <emu-nt id="_ref_148"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>
+        <emu-nt id="_ref_145"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="NamedImports" id="prod-NamedImports">
@@ -3329,12 +4118,12 @@ li.menu-search-result-term:before {
     </emu-rhs>
     <emu-rhs a="g1js-lhi">
         <emu-t>{</emu-t>
-        <emu-nt id="_ref_149"><a href="#prod-ImportsList">ImportsList</a></emu-nt>
+        <emu-nt id="_ref_146"><a href="#prod-ImportsList">ImportsList</a></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
     <emu-rhs a="bxjtogxx">
         <emu-t>{</emu-t>
-        <emu-nt id="_ref_150"><a href="#prod-ImportsList">ImportsList</a></emu-nt>
+        <emu-nt id="_ref_147"><a href="#prod-ImportsList">ImportsList</a></emu-nt>
         <emu-t>,</emu-t>
         <emu-t>}</emu-t>
     </emu-rhs>
@@ -3342,27 +4131,27 @@ li.menu-search-result-term:before {
 <emu-production name="FromClause" id="prod-FromClause">
     <emu-nt><a href="#prod-FromClause">FromClause</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="rev6es22">
         <emu-t>from</emu-t>
-        <emu-nt id="_ref_151"><a href="#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt>
+        <emu-nt id="_ref_148"><a href="#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ImportsList" id="prod-ImportsList">
     <emu-nt><a href="#prod-ImportsList">ImportsList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="upllvvnq">
-        <emu-nt id="_ref_152"><a href="#prod-ImportSpecifier">ImportSpecifier</a></emu-nt>
+        <emu-nt id="_ref_149"><a href="#prod-ImportSpecifier">ImportSpecifier</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="ggcfvgot">
-        <emu-nt id="_ref_153"><a href="#prod-ImportsList">ImportsList</a></emu-nt>
+        <emu-nt id="_ref_150"><a href="#prod-ImportsList">ImportsList</a></emu-nt>
         <emu-t>,</emu-t>
-        <emu-nt id="_ref_154"><a href="#prod-ImportSpecifier">ImportSpecifier</a></emu-nt>
+        <emu-nt id="_ref_151"><a href="#prod-ImportSpecifier">ImportSpecifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ImportSpecifier" id="prod-ImportSpecifier">
     <emu-nt><a href="#prod-ImportSpecifier">ImportSpecifier</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="vt7awvcp">
-        <emu-nt id="_ref_155"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>
+        <emu-nt id="_ref_152"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="nso-0w0x">
         <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleExportName">ModuleExportName</a></emu-nt>
         <emu-t>as</emu-t>
-        <emu-nt id="_ref_156"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>
+        <emu-nt id="_ref_153"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ModuleSpecifier" id="prod-ModuleSpecifier">
@@ -3379,7 +4168,7 @@ li.menu-search-result-term:before {
 
     <emu-clause id="sec-static-semantics-importentries" oldids="sec-module-semantics-static-semantics-importentries,sec-imports-static-semantics-importentries" type="syntax-directed operation" aoid="ImportEntries"><span id="sec-imports-static-semantics-importentries"></span><span id="sec-module-semantics-static-semantics-importentries"></span>
       <h1><span class="secnum">16.2.1</span> Static Semantics: ImportEntries ( )</h1>
-      <p>The <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operation</a></emu-xref> ImportEntries takes no arguments and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#importentry-record" id="_ref_109"><a href="#importentry-record">ImportEntry Records</a></emu-xref>. It is defined piecewise over the following productions:</p>
+      <p>The <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operation</a></emu-xref> ImportEntries takes no arguments and returns a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> of <emu-xref href="#importentry-record" id="_ref_110"><a href="#importentry-record">ImportEntry Records</a></emu-xref>. It is defined piecewise over the following productions:</p>
       <emu-grammar><emu-production name="Module" collapsed="">
     <emu-nt><a href="https://tc39.es/ecma262/#prod-Module">Module</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="n7nathbb"><emu-gann>[empty]</emu-gann></emu-rhs>
 </emu-production>
@@ -3392,7 +4181,7 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-      <emu-alg><ol><li>Let <var>entries1</var> be <emu-xref aoid="ImportEntries" id="_ref_110"><a href="#sec-static-semantics-importentries">ImportEntries</a></emu-xref> of <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItemList">ModuleItemList</a></emu-nt>.</li><li>Let <var>entries2</var> be <emu-xref aoid="ImportEntries" id="_ref_111"><a href="#sec-static-semantics-importentries">ImportEntries</a></emu-xref> of <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItem">ModuleItem</a></emu-nt>.</li><li>Return the <emu-xref href="#list-concatenation"><a href="https://tc39.es/ecma262/#list-concatenation">list-concatenation</a></emu-xref> of <var>entries1</var> and <var>entries2</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>entries1</var> be <emu-xref aoid="ImportEntries" id="_ref_111"><a href="#sec-static-semantics-importentries">ImportEntries</a></emu-xref> of <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItemList">ModuleItemList</a></emu-nt>.</li><li>Let <var>entries2</var> be <emu-xref aoid="ImportEntries" id="_ref_112"><a href="#sec-static-semantics-importentries">ImportEntries</a></emu-xref> of <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItem">ModuleItem</a></emu-nt>.</li><li>Return the <emu-xref href="#list-concatenation"><a href="https://tc39.es/ecma262/#list-concatenation">list-concatenation</a></emu-xref> of <var>entries1</var> and <var>entries2</var>.</li></ol></emu-alg>
       <emu-grammar><emu-production name="ModuleItem">
     <emu-nt><a href="https://tc39.es/ecma262/#prod-ModuleItem">ModuleItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ky6bsn7x">
         <emu-nt><a href="https://tc39.es/ecma262/#prod-ExportDeclaration">ExportDeclaration</a></emu-nt>
@@ -3406,17 +4195,17 @@ li.menu-search-result-term:before {
       <emu-grammar><emu-production name="ImportDeclaration" collapsed="">
     <emu-nt><a href="#prod-ImportDeclaration">ImportDeclaration</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="glhuxxec" id="prod-4FL2ok6-">
         <emu-t>import</emu-t>
-        <emu-nt id="_ref_157"><a href="#prod-ImportClause">ImportClause</a></emu-nt>
-        <emu-nt id="_ref_158"><a href="#prod-FromClause">FromClause</a></emu-nt>
+        <emu-nt id="_ref_154"><a href="#prod-ImportClause">ImportClause</a></emu-nt>
+        <emu-nt id="_ref_155"><a href="#prod-FromClause">FromClause</a></emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
-      <emu-alg><ol><li>Let <var>module</var> be the sole element of <emu-xref aoid="ModuleRequests" id="_ref_112"><a href="#sec-static-semantics-modulerequests">ModuleRequests</a></emu-xref> of <emu-nt id="_ref_159"><a href="#prod-FromClause">FromClause</a></emu-nt>.</li><li>Return <emu-xref aoid="ImportEntriesForModule"><a href="https://tc39.es/ecma262/#sec-static-semantics-importentriesformodule">ImportEntriesForModule</a></emu-xref> of <emu-nt id="_ref_160"><a href="#prod-ImportClause">ImportClause</a></emu-nt> with argument <var>module</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>module</var> be the <del>sole element of <emu-xref aoid="ModuleRequests" id="_ref_113"><a href="#sec-static-semantics-modulerequests">ModuleRequests</a></emu-xref></del><ins><emu-xref aoid="SV"><a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a></emu-xref></ins> of <emu-nt id="_ref_156"><a href="#prod-FromClause">FromClause</a></emu-nt>.</li><li>Return <emu-xref aoid="ImportEntriesForModule"><a href="https://tc39.es/ecma262/#sec-static-semantics-importentriesformodule">ImportEntriesForModule</a></emu-xref> of <emu-nt id="_ref_157"><a href="#prod-ImportClause">ImportClause</a></emu-nt> with argument <var>module</var>.</li></ol></emu-alg>
       <emu-grammar><emu-production name="ImportDeclaration" collapsed="">
     <emu-nt><a href="#prod-ImportDeclaration">ImportDeclaration</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="odcuzpbi" id="prod--ST7ch2j">
         <emu-t>import</emu-t>
-        <emu-nt id="_ref_161"><a href="#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt>
+        <emu-nt id="_ref_158"><a href="#prod-ModuleSpecifier">ModuleSpecifier</a></emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production>
@@ -3426,13 +4215,13 @@ li.menu-search-result-term:before {
     <emu-nt><a href="#prod-ImportDeclaration">ImportDeclaration</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="dch9dh2n" id="prod-aTBBdt4A">
         <emu-t>import</emu-t>
         <emu-t>source</emu-t>
-        <emu-nt id="_ref_162"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>
-        <emu-nt id="_ref_163"><a href="#prod-FromClause">FromClause</a></emu-nt>
+        <emu-nt id="_ref_159"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>
+        <emu-nt id="_ref_160"><a href="#prod-FromClause">FromClause</a></emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production></ins>
 </emu-grammar>
-      <emu-alg><ol><li><ins>Let <var>localName</var> be the sole element of <emu-xref aoid="BoundNames"><a href="https://tc39.es/ecma262/#sec-static-semantics-boundnames">BoundNames</a></emu-xref> of <emu-nt id="_ref_164"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>.</ins></li><li><ins>Let <var>entry</var> be the <emu-xref href="#importentry-record" id="_ref_113"><a href="#importentry-record">ImportEntry Record</a></emu-xref> { [[ModuleRequest]]: <var>module</var>, [[ImportName]]: <emu-const>source</emu-const>, [[LocalName]]: <var>localName</var> }.</ins></li><li><ins>Return « <var>entry</var> »</ins>.</li></ol></emu-alg>
+      <emu-alg><ol><li><ins>Let <var>module</var> be the <emu-xref aoid="SV"><a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a></emu-xref> of <emu-nt id="_ref_161"><a href="#prod-FromClause">FromClause</a></emu-nt>.</ins></li><li><ins>Let <var>localName</var> be the sole element of <emu-xref aoid="BoundNames"><a href="https://tc39.es/ecma262/#sec-static-semantics-boundnames">BoundNames</a></emu-xref> of <emu-nt id="_ref_162"><a href="#prod-ImportedBinding">ImportedBinding</a></emu-nt>.</ins></li><li><ins>Let <var>entry</var> be the <emu-xref href="#importentry-record" id="_ref_114"><a href="#importentry-record">ImportEntry Record</a></emu-xref> { [[ModuleRequest]]: <var>module</var>, [[ImportName]]: <emu-const>source</emu-const>, [[LocalName]]: <var>localName</var> }.</ins></li><li><ins>Return « <var>entry</var> »</ins>.</li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 </emu-clause>
@@ -3442,17 +4231,17 @@ li.menu-search-result-term:before {
   <emu-clause id="sec-module-source-objects">
     <h1><span class="secnum">28.1</span> <ins>Module Source Objects</ins></h1>
     <p>Module Source Objects represent modules in their source import phase, which are not linked, instantiated or executed.</p>
-    <p>All Module Source Objects should have a prototype of <emu-xref href="#sec-%abstractmodulesource%-constructor" id="_ref_114"><a href="#sec-%abstractmodulesource%-constructor">%AbstractModuleSource%</a></emu-xref>.prototype and define a [[ModuleSourceClassName]] internal slot.</p>
-    <p><emu-xref href="#host"><a href="https://tc39.es/ecma262/#host">Hosts</a></emu-xref> may define their own Module Source subclasses for custom module record types.</p>
+    <p>All Module Source Objects must define a [[ModuleSourceClassName]] internal slot.</p>
+    <p>All Module Source Objects should have a prototype of %AbstractModuleSource%.prototype.</p>
+    <p><emu-xref href="#host"><a href="https://tc39.es/ecma262/#host">Hosts</a></emu-xref> may define their own %AbstractModuleSource% subclasses for custom module types.</p>
 
     <emu-clause id="sec-%abstractmodulesource%-constructor">
       <h1><span class="secnum">28.1.1</span> The %AbstractModuleSource% Constructor</h1>
       <p>The %AbstractModuleSource% <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref>:</p>
       <ul>
-        <li>is <dfn>%AbstractModuleSource%</dfn>.</li>
-        <li>along with its corresponding prototype object, provides common properties that are inherited by module source <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructors</a></emu-xref> and their instances.</li>
+        <li>along with its corresponding prototype object, provides common properties that are inherited by Module Source <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructors</a></emu-xref> and their instances.</li>
         <li>does not have a global name or appear as a property of the <emu-xref href="#sec-global-object"><a href="https://tc39.es/ecma262/#sec-global-object">global object</a></emu-xref>.</li>
-        <li>acts as the abstract superclass of the <var>ModuleSource</var> <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref>.</li>
+        <li>acts as a common superclass of the <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructors</a></emu-xref> of Module Source Objects.</li>
         <li>will throw an error when invoked, because it is an abstract class <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref>. The module source <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructors</a></emu-xref> do not perform a <code>super</code> call to it.</li>
       </ul>
 
@@ -3465,7 +4254,7 @@ li.menu-search-result-term:before {
 
     <emu-clause id="sec-properties-of-the-%abstractmodulesource%-intrinsic-object">
       <h1><span class="secnum">28.1.2</span> Properties of the %AbstractModuleSource% Intrinsic Object</h1>
-      <p>The <emu-xref href="#sec-%abstractmodulesource%-constructor" id="_ref_115"><a href="#sec-%abstractmodulesource%-constructor">%AbstractModuleSource%</a></emu-xref> intrinsic object:</p>
+      <p>The %AbstractModuleSource% intrinsic object:</p>
       <ul>
         <li>has a [[Prototype]] internal slot whose value is <emu-xref href="#sec-properties-of-the-function-prototype-object"><a href="https://tc39.es/ecma262/#sec-properties-of-the-function-prototype-object">%Function.prototype%</a></emu-xref>.</li>
         <li>has a <emu-val>"name"</emu-val> property whose value is <emu-val>"AbstractModuleSource"</emu-val>.</li>
@@ -3474,7 +4263,7 @@ li.menu-search-result-term:before {
 
       <emu-clause id="sec-%abstractmodulesource%.prototype">
         <h1><span class="secnum">28.1.2.1</span> %AbstractModuleSource%.prototype</h1>
-        <p>The initial value of <emu-xref href="#sec-%abstractmodulesource%-constructor" id="_ref_116"><a href="#sec-%abstractmodulesource%-constructor">%AbstractModuleSource%</a></emu-xref><code>.prototype</code> is the <emu-xref href="#sec-properties-of-the-%abstractmodulesource%-prototype-object" id="_ref_117"><a href="#sec-properties-of-the-%abstractmodulesource%-prototype-object">%AbstractModuleSource% prototype object</a></emu-xref>.</p>
+        <p>The initial value of %AbstractModuleSource%<code>.prototype</code> is the <emu-xref href="#sec-properties-of-the-%abstractmodulesource%-prototype-object" id="_ref_115"><a href="#sec-properties-of-the-%abstractmodulesource%-prototype-object">%AbstractModuleSource% prototype object</a></emu-xref>.</p>
         <p>This property has the attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }.</p>
       </emu-clause>
     </emu-clause>
@@ -3486,19 +4275,18 @@ li.menu-search-result-term:before {
         <li>has a [[Prototype]] internal slot whose value is <emu-xref href="#sec-properties-of-the-object-prototype-object"><a href="https://tc39.es/ecma262/#sec-properties-of-the-object-prototype-object">%Object.prototype%</a></emu-xref>.</li>
         <li>is <dfn>%AbstractModuleSource.prototype%</dfn>.</li>
         <li>is an <emu-xref href="#ordinary-object"><a href="https://tc39.es/ecma262/#ordinary-object">ordinary object</a></emu-xref>.</li>
-        <li>does not have a global name or appear as a property of the <emu-xref href="#sec-global-object"><a href="https://tc39.es/ecma262/#sec-global-object">global object</a></emu-xref>.</li>
         <li>has the following properties:</li>
       </ul>
 
       <emu-clause id="sec-%abstractmodulesource%.prototype.constructor">
         <h1><span class="secnum">28.1.3.1</span> %AbstractModuleSource%.prototype.constructor</h1>
-        <p>The initial value of <emu-xref href="#sec-%abstractmodulesource%-constructor" id="_ref_118"><a href="#sec-%abstractmodulesource%-constructor">%AbstractModuleSource%</a></emu-xref><code>.prototype.constructor</code> is <emu-xref href="#sec-%abstractmodulesource%-constructor" id="_ref_119"><a href="#sec-%abstractmodulesource%-constructor">%AbstractModuleSource%</a></emu-xref>.</p>
+        <p>The initial value of %AbstractModuleSource%<code>.prototype.constructor</code> is %AbstractModuleSource%.</p>
       </emu-clause>
 
       <emu-clause id="sec-get-%abstractmodulesource%.prototype.@@tostringtag">
-        <h1><span class="secnum">28.1.3.2</span> get %AbstractModuleSource%.prototype [ @@toStringTag ] ( )</h1>
-        <p><emu-xref href="#sec-%abstractmodulesource%-constructor" id="_ref_120"><a href="#sec-%abstractmodulesource%-constructor">%AbstractModuleSource%</a></emu-xref>.prototype <code>[@@toStringTag]</code> is an <emu-xref href="#sec-object-type"><a href="https://tc39.es/ecma262/#sec-object-type">accessor property</a></emu-xref> whose set accessor function is <emu-val>undefined</emu-val>. Its get accessor function performs the following steps when called:</p>
-        <emu-alg><ol><li>Let <var>O</var> be the <emu-val>this</emu-val> value.</li><li>If <var>O</var> <emu-xref href="#sec-object-type"><a href="https://tc39.es/ecma262/#sec-object-type">is not an Object</a></emu-xref>, return <emu-val>undefined</emu-val>.</li><li>If <var>O</var> does not have a [[ModuleSourceClassName]] internal slot, return <emu-val>undefined</emu-val>.</li><li>Let <var>name</var> be <var>O</var>.[[ModuleSourceClassName]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>name</var> <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">is a String</a></emu-xref>.</li><li>Return <var>name</var>.</li></ol></emu-alg>
+        <h1><span class="secnum">28.1.3.2</span> get %AbstractModuleSource%.prototype [ @@toStringTag ]</h1>
+        <p>%AbstractModuleSource%.prototype <code>[@@toStringTag]</code> is an <emu-xref href="#sec-object-type" id="_ref_116"><a href="#sec-object-type">accessor property</a></emu-xref> whose set accessor function is <emu-val>undefined</emu-val>. Its get accessor function performs the following steps when called:</p>
+        <emu-alg><ol><li>Let <var>O</var> be the <emu-val>this</emu-val> value.</li><li>If <var>O</var> <emu-xref href="#sec-object-type" id="_ref_117"><a href="#sec-object-type">is not an Object</a></emu-xref>, return <emu-val>undefined</emu-val>.</li><li>If <var>O</var> does not have a [[ModuleSourceClassName]] internal slot, return <emu-val>undefined</emu-val>.</li><li>Let <var>name</var> be <var>O</var>.[[ModuleSourceClassName]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>name</var> <emu-xref href="#sec-ecmascript-language-types-string-type"><a href="https://tc39.es/ecma262/#sec-ecmascript-language-types-string-type">is a String</a></emu-xref>.</li><li>Return <var>name</var>.</li></ol></emu-alg>
         <p>This property has the attributes { [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.</p>
         <p>The initial value of the <emu-val>"name"</emu-val> property of this function is <emu-val>"get [Symbol.toStringTag]"</emu-val>.</p>
       </emu-clause>
@@ -3513,7 +4301,7 @@ li.menu-search-result-term:before {
     <h1><span class="secnum">A.1</span> Host-defined Fields</h1>
     <p>[[HostDefined]] on <emu-xref href="#realm-record"><a href="https://tc39.es/ecma262/#realm-record">Realm Records</a></emu-xref>: See <emu-xref href="#table-realm-record-fields"><a href="https://tc39.es/ecma262/#table-realm-record-fields">Table 24</a></emu-xref>.</p>
     <p>[[HostDefined]] on <emu-xref href="#script-record"><a href="https://tc39.es/ecma262/#script-record">Script Records</a></emu-xref>: See <emu-xref href="#table-script-records"><a href="https://tc39.es/ecma262/#table-script-records">Table 39</a></emu-xref>.</p>
-    <p>[[HostDefined]] on <emu-xref href="#sec-abstract-module-records" id="_ref_121"><a href="#sec-abstract-module-records">Module Records</a></emu-xref>: See <emu-xref href="#table-module-record-fields" id="_ref_9"><a href="#table-module-record-fields">Table 2</a></emu-xref>.</p>
+    <p>[[HostDefined]] on <emu-xref href="#sec-abstract-module-records" id="_ref_118"><a href="#sec-abstract-module-records">Module Records</a></emu-xref>: See <emu-xref href="#table-module-record-fields" id="_ref_11"><a href="#table-module-record-fields">Table 3</a></emu-xref>.</p>
     <p>[[HostDefined]] on <emu-xref href="#sec-jobcallback-records"><a href="https://tc39.es/ecma262/#sec-jobcallback-records">JobCallback Records</a></emu-xref>: See <emu-xref href="#table-jobcallback-records"><a href="https://tc39.es/ecma262/#table-jobcallback-records">Table 28</a></emu-xref>.</p>
     <p>[[HostSynchronizesWith]] on Candidate Executions: See <emu-xref href="#table-candidate-execution-records"><a href="https://tc39.es/ecma262/#table-candidate-execution-records">Table 90</a></emu-xref>.</p>
     <p>[[IsHTMLDDA]]: See <emu-xref href="#sec-IsHTMLDDA-internal-slot"><a href="https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot">B.3.6</a></emu-xref>.</p>

--- a/spec.emu
+++ b/spec.emu
@@ -10,9 +10,11 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
 </pre>
 
 <emu-clause id="sec-ecmascript-data-types-and-values" aoid="Type">
+  <h1>ECMAScript Data Types and Values</h1>
   <emu-clause id="sec-ecmascript-language-types">
+    <h1>ECMAScript Language Types</h1>
     <emu-clause id="sec-object-type">
-
+      <h1>Object Type</h1>
       <emu-clause id="sec-well-known-intrinsic-objects">
         <h1>Well-Known Intrinsic Objects</h1>
         <p>Well-known intrinsics are built-in objects that are explicitly referenced by the algorithms of this specification and which usually have realm-specific identities. Unless otherwise specified each intrinsic object actually corresponds to a set of similar objects, one per realm.</p>

--- a/spec.emu
+++ b/spec.emu
@@ -5,9 +5,793 @@
 <script src="./spec.js"></script>
 <pre class="metadata">
 title: Source Phase Imports
-stage: 2
+stage: 3
 contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
 </pre>
+
+<emu-clause id="sec-ecmascript-data-types-and-values" aoid="Type">
+  <emu-clause id="sec-ecmascript-language-types">
+    <emu-clause id="sec-object-type">
+
+      <emu-clause id="sec-well-known-intrinsic-objects">
+        <h1>Well-Known Intrinsic Objects</h1>
+        <p>Well-known intrinsics are built-in objects that are explicitly referenced by the algorithms of this specification and which usually have realm-specific identities. Unless otherwise specified each intrinsic object actually corresponds to a set of similar objects, one per realm.</p>
+        <p>Within this specification a reference such as %name% means the intrinsic object, associated with the current realm, corresponding to the name. A reference such as %name.a.b% means, as if the *"b"* property of the value of the *"a"* property of the intrinsic object %name% was accessed prior to any ECMAScript code being evaluated. Determination of the current realm and its intrinsics is described in <emu-xref href="#sec-execution-contexts"></emu-xref>. The well-known intrinsics are listed in <emu-xref href="#table-well-known-intrinsic-objects"></emu-xref>.</p>
+        <emu-table id="table-well-known-intrinsic-objects" caption="Well-Known Intrinsic Objects" oldids="table-7">
+          <table>
+            <tr>
+              <th>
+                Intrinsic Name
+              </th>
+              <th>
+                Global Name
+              </th>
+              <th>
+                ECMAScript Language Association
+              </th>
+            </tr>
+            <tr>
+              <td>
+                %AbstractModuleSource%
+              </td>
+              <td>
+              </td>
+              <td>
+                The %AbstractModuleSource% constructor (<emu-xref href="#sec-%abstractmodulesource%-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %AggregateError%
+              </td>
+              <td>
+                `AggregateError`
+              </td>
+              <td>
+                The `AggregateError` constructor (<emu-xref href="#sec-aggregate-error-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Array%
+              </td>
+              <td>
+                `Array`
+              </td>
+              <td>
+                The Array constructor (<emu-xref href="#sec-array-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %ArrayBuffer%
+              </td>
+              <td>
+                `ArrayBuffer`
+              </td>
+              <td>
+                The ArrayBuffer constructor (<emu-xref href="#sec-arraybuffer-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %ArrayIteratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of Array iterator objects (<emu-xref href="#sec-array-iterator-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %AsyncFromSyncIteratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of async-from-sync iterator objects (<emu-xref href="#sec-async-from-sync-iterator-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %AsyncFunction%
+              </td>
+              <td>
+              </td>
+              <td>
+                The constructor of async function objects (<emu-xref href="#sec-async-function-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %AsyncGeneratorFunction%
+              </td>
+              <td>
+              </td>
+              <td>
+                The constructor of async generator function objects (<emu-xref href="#sec-asyncgeneratorfunction-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %AsyncGeneratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of async generator objects (<emu-xref href="#sec-asyncgenerator-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %AsyncIteratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                An object that all standard built-in async iterator objects indirectly inherit from
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Atomics%
+              </td>
+              <td>
+                `Atomics`
+              </td>
+              <td>
+                The `Atomics` object (<emu-xref href="#sec-atomics-object"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %BigInt%
+              </td>
+              <td>
+                `BigInt`
+              </td>
+              <td>
+                The BigInt constructor (<emu-xref href="#sec-bigint-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %BigInt64Array%
+              </td>
+              <td>
+                `BigInt64Array`
+              </td>
+              <td>
+                The BigInt64Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %BigUint64Array%
+              </td>
+              <td>
+                `BigUint64Array`
+              </td>
+              <td>
+                The BigUint64Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Boolean%
+              </td>
+              <td>
+                `Boolean`
+              </td>
+              <td>
+                The Boolean constructor (<emu-xref href="#sec-boolean-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %DataView%
+              </td>
+              <td>
+                `DataView`
+              </td>
+              <td>
+                The DataView constructor (<emu-xref href="#sec-dataview-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Date%
+              </td>
+              <td>
+                `Date`
+              </td>
+              <td>
+                The Date constructor (<emu-xref href="#sec-date-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %decodeURI%
+              </td>
+              <td>
+                `decodeURI`
+              </td>
+              <td>
+                The `decodeURI` function (<emu-xref href="#sec-decodeuri-encodeduri"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %decodeURIComponent%
+              </td>
+              <td>
+                `decodeURIComponent`
+              </td>
+              <td>
+                The `decodeURIComponent` function (<emu-xref href="#sec-decodeuricomponent-encodeduricomponent"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %encodeURI%
+              </td>
+              <td>
+                `encodeURI`
+              </td>
+              <td>
+                The `encodeURI` function (<emu-xref href="#sec-encodeuri-uri"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %encodeURIComponent%
+              </td>
+              <td>
+                `encodeURIComponent`
+              </td>
+              <td>
+                The `encodeURIComponent` function (<emu-xref href="#sec-encodeuricomponent-uricomponent"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Error%
+              </td>
+              <td>
+                `Error`
+              </td>
+              <td>
+                The Error constructor (<emu-xref href="#sec-error-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %eval%
+              </td>
+              <td>
+                `eval`
+              </td>
+              <td>
+                The `eval` function (<emu-xref href="#sec-eval-x"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %EvalError%
+              </td>
+              <td>
+                `EvalError`
+              </td>
+              <td>
+                The EvalError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-evalerror"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %FinalizationRegistry%
+              </td>
+              <td>
+                `FinalizationRegistry`
+              </td>
+              <td>
+                The FinalizationRegistry constructor (<emu-xref href="#sec-finalization-registry-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Float32Array%
+              </td>
+              <td>
+                `Float32Array`
+              </td>
+              <td>
+                The Float32Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Float64Array%
+              </td>
+              <td>
+                `Float64Array`
+              </td>
+              <td>
+                The Float64Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %ForInIteratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of For-In iterator objects (<emu-xref href="#sec-for-in-iterator-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Function%
+              </td>
+              <td>
+                `Function`
+              </td>
+              <td>
+                The Function constructor (<emu-xref href="#sec-function-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %GeneratorFunction%
+              </td>
+              <td>
+              </td>
+              <td>
+                The constructor of generator function objects (<emu-xref href="#sec-generatorfunction-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %GeneratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of generator objects (<emu-xref href="#sec-generator-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Int8Array%
+              </td>
+              <td>
+                `Int8Array`
+              </td>
+              <td>
+                The Int8Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Int16Array%
+              </td>
+              <td>
+                `Int16Array`
+              </td>
+              <td>
+                The Int16Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Int32Array%
+              </td>
+              <td>
+                `Int32Array`
+              </td>
+              <td>
+                The Int32Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %isFinite%
+              </td>
+              <td>
+                `isFinite`
+              </td>
+              <td>
+                The `isFinite` function (<emu-xref href="#sec-isfinite-number"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %isNaN%
+              </td>
+              <td>
+                `isNaN`
+              </td>
+              <td>
+                The `isNaN` function (<emu-xref href="#sec-isnan-number"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %IteratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                An object that all standard built-in iterator objects indirectly inherit from
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %JSON%
+              </td>
+              <td>
+                `JSON`
+              </td>
+              <td>
+                The `JSON` object (<emu-xref href="#sec-json-object"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Map%
+              </td>
+              <td>
+                `Map`
+              </td>
+              <td>
+                The Map constructor (<emu-xref href="#sec-map-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %MapIteratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of Map iterator objects (<emu-xref href="#sec-map-iterator-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Math%
+              </td>
+              <td>
+                `Math`
+              </td>
+              <td>
+                The `Math` object (<emu-xref href="#sec-math-object"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Number%
+              </td>
+              <td>
+                `Number`
+              </td>
+              <td>
+                The Number constructor (<emu-xref href="#sec-number-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Object%
+              </td>
+              <td>
+                `Object`
+              </td>
+              <td>
+                The Object constructor (<emu-xref href="#sec-object-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %parseFloat%
+              </td>
+              <td>
+                `parseFloat`
+              </td>
+              <td>
+                The `parseFloat` function (<emu-xref href="#sec-parsefloat-string"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %parseInt%
+              </td>
+              <td>
+                `parseInt`
+              </td>
+              <td>
+                The `parseInt` function (<emu-xref href="#sec-parseint-string-radix"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Promise%
+              </td>
+              <td>
+                `Promise`
+              </td>
+              <td>
+                The Promise constructor (<emu-xref href="#sec-promise-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Proxy%
+              </td>
+              <td>
+                `Proxy`
+              </td>
+              <td>
+                The Proxy constructor (<emu-xref href="#sec-proxy-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %RangeError%
+              </td>
+              <td>
+                `RangeError`
+              </td>
+              <td>
+                The RangeError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-rangeerror"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %ReferenceError%
+              </td>
+              <td>
+                `ReferenceError`
+              </td>
+              <td>
+                The ReferenceError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-referenceerror"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Reflect%
+              </td>
+              <td>
+                `Reflect`
+              </td>
+              <td>
+                The `Reflect` object (<emu-xref href="#sec-reflect-object"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %RegExp%
+              </td>
+              <td>
+                `RegExp`
+              </td>
+              <td>
+                The RegExp constructor (<emu-xref href="#sec-regexp-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %RegExpStringIteratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of RegExp String Iterator objects (<emu-xref href="#sec-regexp-string-iterator-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Set%
+              </td>
+              <td>
+                `Set`
+              </td>
+              <td>
+                The Set constructor (<emu-xref href="#sec-set-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %SetIteratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of Set iterator objects (<emu-xref href="#sec-set-iterator-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %SharedArrayBuffer%
+              </td>
+              <td>
+                `SharedArrayBuffer`
+              </td>
+              <td>
+                The SharedArrayBuffer constructor (<emu-xref href="#sec-sharedarraybuffer-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %String%
+              </td>
+              <td>
+                `String`
+              </td>
+              <td>
+                The String constructor (<emu-xref href="#sec-string-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %StringIteratorPrototype%
+              </td>
+              <td>
+              </td>
+              <td>
+                The prototype of String iterator objects (<emu-xref href="#sec-string-iterator-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Symbol%
+              </td>
+              <td>
+                `Symbol`
+              </td>
+              <td>
+                The Symbol constructor (<emu-xref href="#sec-symbol-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %SyntaxError%
+              </td>
+              <td>
+                `SyntaxError`
+              </td>
+              <td>
+                The SyntaxError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-syntaxerror"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %ThrowTypeError%
+              </td>
+              <td>
+              </td>
+              <td>
+                A function object that unconditionally throws a new instance of %TypeError%
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %TypedArray%
+              </td>
+              <td>
+              </td>
+              <td>
+                The super class of all typed Array constructors (<emu-xref href="#sec-%typedarray%-intrinsic-object"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %TypeError%
+              </td>
+              <td>
+                `TypeError`
+              </td>
+              <td>
+                The TypeError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-typeerror"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Uint8Array%
+              </td>
+              <td>
+                `Uint8Array`
+              </td>
+              <td>
+                The Uint8Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Uint8ClampedArray%
+              </td>
+              <td>
+                `Uint8ClampedArray`
+              </td>
+              <td>
+                The Uint8ClampedArray constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Uint16Array%
+              </td>
+              <td>
+                `Uint16Array`
+              </td>
+              <td>
+                The Uint16Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %Uint32Array%
+              </td>
+              <td>
+                `Uint32Array`
+              </td>
+              <td>
+                The Uint32Array constructor (<emu-xref href="#sec-typedarray-objects"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %URIError%
+              </td>
+              <td>
+                `URIError`
+              </td>
+              <td>
+                The URIError constructor (<emu-xref href="#sec-native-error-types-used-in-this-standard-urierror"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %WeakMap%
+              </td>
+              <td>
+                `WeakMap`
+              </td>
+              <td>
+                The WeakMap constructor (<emu-xref href="#sec-weakmap-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %WeakRef%
+              </td>
+              <td>
+                `WeakRef`
+              </td>
+              <td>
+                The WeakRef constructor (<emu-xref href="#sec-weak-ref-constructor"></emu-xref>)
+              </td>
+            </tr>
+            <tr>
+              <td>
+                %WeakSet%
+              </td>
+              <td>
+                `WeakSet`
+              </td>
+              <td>
+                The WeakSet constructor (<emu-xref href="#sec-weakset-constructor"></emu-xref>)
+              </td>
+            </tr>
+          </table>
+        </emu-table>
+        <emu-note>
+          <p>Additional entries in <emu-xref href="#table-additional-well-known-intrinsic-objects"></emu-xref>.</p>
+        </emu-note>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+</emu-clause>
 
 <emu-clause id="sec-ecmascript-language-expressions" number="13">
   <h1>ECMAScript Language: Expressions</h1>
@@ -27,9 +811,8 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
       <emu-clause id="sec-import-call-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
 
-        <emu-grammar>ImportCall : `import` `(` AssignmentExpression `)`</emu-grammar>
+        <emu-grammar>ImportCall : `import` `(` AssignmentExpression[+In, ?Yield, ?Await] `)`</emu-grammar>
         <emu-alg>
-          1. <ins>Return ? EvaluateImportCall(|AssignmentExpression|, ~evaluation~).</ins>
           1. <del>Let _referrer_ be GetActiveScriptOrModule().</del>
           1. <del>If _referrer_ is *null*, set _referrer_ to the current Realm Record.</del>
           1. <del>Let _argRef_ be ? Evaluation of |AssignmentExpression|.</del>
@@ -39,6 +822,7 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
           1. <del>IfAbruptRejectPromise(_specifierString_, _promiseCapability_).</del>
           1. <del>Perform HostLoadImportedModule(_referrer_, _specifierString_, ~empty~, _promiseCapability_).</del>
           1. <del>Return _promiseCapability_.[[Promise]].</del>
+          1. <ins>Return ? EvaluateImportCall(|AssignmentExpression|, ~evaluation~).</ins>
         </emu-alg>
 
         <emu-grammar><ins>ImportCall : `import` `.` `source` `(` AssignmentExpression[+In, ?Yield, ?Await] `)`</ins></emu-grammar>
@@ -88,11 +872,11 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
               1. Return ~unused~.
             1. Let _module_ be _moduleCompletion_.[[Value]].
             1. <ins>If _phase_ is ~source~, then</ins>
-              1. <ins>Let _moduleSourceObject_ be Completion(_module_.GetModuleSource()).</ins>
-              1. <ins>If _moduleSourceObject_ is an abrupt completion, then</ins>
-                1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _moduleSourceObject_.[[Value]] &raquo;).</ins>
+              1. <ins>Let _moduleSourceCompletion_ be Completion(_module_.GetModuleSource()).</ins>
+              1. <ins>If _moduleSourceCompletion_ is an abrupt completion, then</ins>
+                1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo; _moduleSourceCompletion_.[[Value]] &raquo;).</ins>
               1. <ins>Else,</ins>
-                1. <ins>Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _moduleSourceObject_.[[Value]] &raquo;).</ins>
+                1. <ins>Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo; _moduleSourceCompletion_.[[Value]] &raquo;).</ins>
               1. <ins>Return ~unused~.</ins>
             1. Let _loadPromise_ be _module_.LoadRequestedModules().
             1. Let _rejectedClosure_ be a new Abstract Closure with parameters (_reason_) that captures _promiseCapability_ and performs the following steps when called:
@@ -153,7 +937,7 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
                   [[Specifier]]
                 </td>
                 <td>
-                  String
+                  a String
                 </td>
                 <td>
                   The module specifier
@@ -376,9 +1160,10 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
                 <ins>GetModuleSource()</ins>
               </td>
               <td>
-                <p><ins>It returns either a normal completion completion for the Module Source Object corresponding to this source Module Record's source phase (<emu-xref href="#sec-module-source-objects"></emu-xref>), or a throw completion.</ins></p>
-                <ins>When called multiple times on the same Module Record, if GetModuleSource() returns a normal completion it must always return a normal completion containing the same object.</ins>
-                <ins>The returned object should be an instance of a subclass of %AbstractModuleSource%, and it must have an internal slot [[ModuleSourceClassName]].</ins>
+                <p><ins>It returns either a normal completion containing the Module Source Object corresponding to this source Module Record's source phase (<emu-xref href="#sec-module-source-objects"></emu-xref>), or a throw completion.</ins></p>
+                <p><ins>When called multiple times on the same Module Record, if GetModuleSource() returns a normal completion it must always return a normal completion containing the same object.</ins></p>
+                <p><ins>The returned object should be an instance of a subclass of %AbstractModuleSource%, and it must have an internal slot [[ModuleSourceClassName]].</ins></p>
+                <p><ins>For Module Records that do not have a source representation, GetModuleSource() must always return a throw completion whose [[Value]] is a *ReferenceError*.</ins></p>
               </td>
             </tr>
           </table>
@@ -455,7 +1240,7 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
                 a List of <del>Strings</del><ins>ModuleRequest Records</ins>
               </td>
               <td>
-                A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module, <ins>along with their maximum associated phase (~source~ or ~evaluation~)</ins>. The List is in source text occurrence order.
+                A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module, <ins>along with their associated phase (~source~ or ~evaluation~)</ins>. The List is in source text occurrence order.
               </td>
             </tr>
             <tr>
@@ -539,13 +1324,20 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
             <dt>description</dt>
             <dd>It populates the [[LoadedModules]] of all the Module Records in the dependency graph of _module_ (most of the work is done by the auxiliary function InnerModuleLoading). It takes an optional _hostDefined_ parameter that is passed to the HostLoadImportedModule hook.</dd>
           </dl>
+          <emu-alg>
+            1. If _hostDefined_ is not present, let _hostDefined_ be ~empty~.
+            1. Let _pc_ be ! NewPromiseCapability(%Promise%).
+            1. Let _state_ be the GraphLoadingState Record { [[IsLoading]]: *true*, [[PendingModulesCount]]: 1, [[Visited]]: « », [[PromiseCapability]]: _pc_, [[HostDefined]]: _hostDefined_ }.
+            1. Perform InnerModuleLoading(_state_, _module_<ins>, ~recursive-load~</ins>).
+            1. Return _pc_.[[Promise]].
+          </emu-alg>
 
           <emu-clause id="sec-InnerModuleLoading" type="abstract operation">
             <h1>
               InnerModuleLoading (
                 _state_: a GraphLoadingState Record,
                 _module_: a Module Record,
-                <ins>_phase_: ~source~ or ~evaluation~,</ins>
+                <ins>_loadType_: ~single~ or ~recursive-load~,</ins>
               ): ~unused~
             </h1>
             <dl class="header">
@@ -555,7 +1347,7 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
 
             <emu-alg>
               1. Assert: _state_.[[IsLoading]] is *true*.
-              1. If _module_ is a Cyclic Module Record, _module_.[[Status]] is ~new~, <del>and</del> _state_.[[Visited]] does not contain _module_<ins>, and _phase_ is ~evaluation~, </ins>then
+              1. If <ins>_loadType_ is ~recursive-load~, </ins>_module_ is a Cyclic Module Record, _module_.[[Status]] is ~new~, and _state_.[[Visited]] does not contain _module_, then
                 1. Append _module_ to _state_.[[Visited]].
                 1. Let _requestedModulesCount_ be the number of elements in _module_.[[RequestedModules]].
                 1. Set _state_.[[PendingModulesCount]] to _state_.[[PendingModulesCount]] + _requestedModulesCount_.
@@ -563,7 +1355,8 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
                 1. <ins>For each ModuleRequest Record _required_ of _module_.[[RequestedModules]], do</ins>
                   1. If _module_.[[LoadedModules]] contains a Record whose [[Specifier]] is _required_<ins>.[[Specifier]]</ins>, then
                     1. Let _record_ be that Record.
-                    1. Perform InnerModuleLoading(_state_, _record_.[[Module]], <ins>_required_.[[Phase]]</ins>).
+                    1. <ins>If _required_.[[Phase]] is ~source~, let _innerLoadType_ be ~single~; otherwise let _innerLoadType_ be ~recursive-load~.</ins>
+                    1. Perform InnerModuleLoading(_state_, _record_.[[Module]], <ins>_innerLoadType_</ins>).
                   1. Else,
                     1. Perform HostLoadImportedModule(_module_, _required_, _state_.[[HostDefined]], _state_).
                     1. NOTE: HostLoadImportedModule will call FinishLoadingImportedModule, which re-enters the graph loading process through ContinueModuleLoading.
@@ -595,7 +1388,8 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
             <emu-alg>
               1. If _state_.[[IsLoading]] is *false*, return ~unused~.
               1. If _moduleCompletion_ is a normal completion, then
-                1. Perform InnerModuleLoading(_state_, _moduleCompletion_.[[Value]]<ins>, _phase_</ins>).
+                1. <ins>If _phase_ is ~source~, let _loadType_ be ~single~; otherwise let _loadType_ be ~recursive-load~.</ins>
+                1. Perform InnerModuleLoading(_state_, _moduleCompletion_.[[Value]]<ins>, _loadType_</ins>).
               1. Else,
                 1. Set _state_.[[IsLoading]] to *false*.
                 1. Perform ! Call(_state_.[[PromiseCapability]].[[Reject]], *undefined*, « _moduleCompletion_.[[Value]] »).
@@ -744,7 +1538,12 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
             </emu-alg>
           </emu-clause>
         </emu-clause>
-        <emu-clause id="sec-getmodulesource" type="concrete method">
+      </emu-clause>
+
+      <emu-clause id="sec-source-text-module-records">
+        <h1>Source Text Module Records</h1>
+
+        <emu-clause id="sec-source-text-module-record-getmodulesource" type="concrete method">
           <h1>
             <ins>
               GetModuleSource ( ): either a normal completion containing an Object or a throw completion
@@ -752,22 +1551,17 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
           </h1>
           <dl class="header">
             <dt>for</dt>
-            <dd>a Cyclic Module Record _module_</dd>
+            <dd>a Source Text Module Record _module_</dd>
 
             <dt>description</dt>
             <dd>
-              <p>Cyclic Module Record provides a default GetModuleSource implementation with an abrupt completion to provide a standard reference error that a source phase import is not available.</p>
+              <p>Source Text Module Record provides a GetModuleSource implementation that always returns an abrupt completion indicating that a source phase import is not available.</p>
             </dd>
           </dl>
           <emu-alg>
-            1. Let _error_ be a newly created *ReferenceError* object.
-            1. Return ThrowCompletion(_error_).
+            1. Throw a *ReferenceError* exception.
           </emu-alg>
         </emu-clause>
-      </emu-clause>
-
-      <emu-clause id="sec-source-text-module-records">
-        <h1>Source Text Module Records</h1>
 
         <emu-clause id="sec-source-text-module-record-initialize-environment" type="concrete method">
           <h1>InitializeEnvironment ( ): either a normal completion containing ~unused~ or a throw completion</h1>
@@ -873,7 +1667,7 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
               a String <del>or ~namespace-object~</del><ins>, ~namespace-object~ or ~source~</ins>
             </td>
             <td>
-              The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value ~namespace-object~ indicates that the import request is for the target module's namespace object. <ins>The value ~source~ represents an import of the import phase representation at that phase name.</ins>
+              The name under which the desired binding is exported by the module identified by [[ModuleRequest]]. The value ~namespace-object~ indicates that the import request is for the target module's namespace object. <ins>The value ~source~ represents an import at the source phase.</ins>
             </td>
           </tr>
           <tr>
@@ -1037,7 +1831,7 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
         </dl>
         <emu-alg>
           1. If _result_ is a normal completion, then
-            1. If _referrer_.[[LoadedModules]] contains a Record _record_ such that _record_.[[Specifier]] is <del>_specifier_</del><ins>_moduleRequest_.[[Specifier]]</ins>, then
+            1. If _referrer_.[[LoadedModules]] contains a Record whose [[Specifier]] is <del>_specifier_</del><ins>_moduleRequest_.[[Specifier]]</ins>, then
               1. Assert: _record_.[[Module]] is _result_.[[Value]].
             1. Else, append the Record { [[Specifier]]: <del>_specifier_</del><ins>_moduleRequest_.[[Specifier]]</ins>, [[Module]]: _result_.[[Value]] } to _referrer_.[[LoadedModules]].
           1. If _payload_ is a GraphLoadingState Record, then
@@ -1118,7 +1912,7 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
       </emu-alg>
       <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
       <emu-alg>
-        1. Let _module_ be the sole element of ModuleRequests of |FromClause|.
+        1. Let _module_ be the <del>sole element of ModuleRequests</del><ins>SV</ins> of |FromClause|.
         1. Return ImportEntriesForModule of |ImportClause| with argument _module_.
       </emu-alg>
       <emu-grammar>ImportDeclaration : `import` ModuleSpecifier `;`</emu-grammar>
@@ -1127,6 +1921,7 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
       </emu-alg>
       <emu-grammar><ins>ImportDeclaration : `import` `source` ImportedBinding FromClause `;`</ins></emu-grammar>
       <emu-alg>
+        1. <ins>Let _module_ be the SV of |FromClause|.</ins>
         1. <ins>Let _localName_ be the sole element of BoundNames of |ImportedBinding|.</ins>
         1. <ins>Let _entry_ be the ImportEntry Record { [[ModuleRequest]]: _module_, [[ImportName]]: ~source~, [[LocalName]]: _localName_ }.</ins>
         1. <ins>Return « _entry_ »</ins>.
@@ -1140,17 +1935,17 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
   <emu-clause id="sec-module-source-objects">
     <h1><ins>Module Source Objects</ins></h1>
     <p>Module Source Objects represent modules in their source import phase, which are not linked, instantiated or executed.</p>
-    <p>All Module Source Objects should have a prototype of %AbstractModuleSource%.prototype and define a [[ModuleSourceClassName]] internal slot.</p>
-    <p>Hosts may define their own Module Source subclasses for custom module record types.</p>
+    <p>All Module Source Objects must define a [[ModuleSourceClassName]] internal slot.</p>
+    <p>All Module Source Objects should have a prototype of %AbstractModuleSource%.prototype.</p>
+    <p>Hosts may define their own %AbstractModuleSource% subclasses for custom module types.</p>
 
     <emu-clause id="sec-%abstractmodulesource%-constructor">
       <h1>The %AbstractModuleSource% Constructor</h1>
       <p>The %AbstractModuleSource% constructor:</p>
       <ul>
-        <li>is <dfn>%AbstractModuleSource%</dfn>.</li>
-        <li>along with its corresponding prototype object, provides common properties that are inherited by module source constructors and their instances.</li>
+        <li>along with its corresponding prototype object, provides common properties that are inherited by Module Source constructors and their instances.</li>
         <li>does not have a global name or appear as a property of the global object.</li>
-        <li>acts as the abstract superclass of the _ModuleSource_ constructor.</li>
+        <li>acts as a common superclass of the constructors of Module Source Objects.</li>
         <li>will throw an error when invoked, because it is an abstract class constructor. The module source constructors do not perform a `super` call to it.</li>
       </ul>
 
@@ -1186,7 +1981,6 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
         <li>has a [[Prototype]] internal slot whose value is %Object.prototype%.</li>
         <li>is <dfn>%AbstractModuleSource.prototype%</dfn>.</li>
         <li>is an ordinary object.</li>
-        <li>does not have a global name or appear as a property of the global object.</li>
         <li>has the following properties:</li>
       </ul>
 
@@ -1196,7 +1990,7 @@ contributors: Luca Casonato, Guy Bedford, Nicolò Ribaudo
       </emu-clause>
 
       <emu-clause id="sec-get-%abstractmodulesource%.prototype.@@tostringtag">
-        <h1>get %AbstractModuleSource%.prototype [ @@toStringTag ] ( )</h1>
+        <h1>get %AbstractModuleSource%.prototype [ @@toStringTag ]</h1>
         <p>%AbstractModuleSource%.prototype `[@@toStringTag]` is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps when called:</p>
         <emu-alg>
           1. Let _O_ be the *this* value.


### PR DESCRIPTION
This re-syncs the spec in this repo to the latest version matching the upstream PR in https://github.com/tc39/ecma262/pull/3094.